### PR TITLE
ModCompatibility: New Namespace + Multi-Corrupt Fix

### DIFF
--- a/RoR2BepInExPack/ModCompatibility/FixMultiCorrupt.cs
+++ b/RoR2BepInExPack/ModCompatibility/FixMultiCorrupt.cs
@@ -74,6 +74,9 @@ internal class FixMultiCorrupt
             c.Emit(OpCodes.Ldarg,1);
             c.EmitDelegate<Func<Inventory,ItemIndex,ItemIndex>>((inventory,pureItem) =>{
                 List<ItemIndex> possibilities = inventory.itemAcquisitionOrder.Where(item => ContagiousItemManager.GetOriginalItemIndex(item) == pureItem).ToList();
+                    if(possibilities.Count == 0){
+                      possibilities = ContagiousItemManager.transformationInfos.Where((info) => info.originalItem == pureItem).Select((info) => info.transformedItem).ToList();
+                    }
                     switch(contagionPriority.Value){
                         case ContagionPriority.First:
                           return possibilities.First();

--- a/RoR2BepInExPack/ModCompatibility/FixMultiCorrupt.cs
+++ b/RoR2BepInExPack/ModCompatibility/FixMultiCorrupt.cs
@@ -1,0 +1,103 @@
+using BepInEx;
+using BepInEx.Configuration;
+using MonoMod.RuntimeDetour;
+using MonoMod.Cil;
+using RoR2;
+using RoR2.Items;
+using RoR2BepInExPack.Reflection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil.Cil;
+using System.Runtime.CompilerServices;
+
+using static RoR2.Items.ContagiousItemManager;
+
+namespace RoR2BepInExPack.ModCompatibility;
+
+internal class FixMultiCorrupt
+{
+
+    private static ILHook _ilhook;
+
+    private static ConditionalWeakTable<Inventory,Dictionary<ItemIndex,int>> alternateTracker = new ConditionalWeakTable<Inventory, Dictionary<ItemIndex, int>>();
+    private static Xoroshiro128Plus voidRNG = null;
+    private static ConfigEntry<ContagionPriority> contagionPriority;
+
+    internal enum ContagionPriority
+    {
+       First,
+       Last,
+       Random,
+       Rarest,
+       Alternate
+    }
+
+
+    internal static void Init(ConfigFile config)
+    {
+        contagionPriority = config.Bind<ContagionPriority>("General","Contagion Priority",ContagionPriority.Random,"Determines behaviour for when multiple results are available for an item transformation.");
+        var ilhookConfig = new ILHookConfig() {ManualApply = true};
+        _ilhook = new ILHook(
+                        typeof(ContagiousItemManager).GetMethod(nameof(ContagiousItemManager.StepInventoryInfection),ReflectionHelper.AllFlags),
+                        FixMultiCorrupt.FixStep,
+                        ref ilhookConfig
+                    );
+    }
+
+    internal static void Enable()
+    {
+        _ilhook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _ilhook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _ilhook.Free();
+    }
+
+    internal static void FixStep(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        bool ILFound = c.TryGotoNext(MoveType.After,
+            x => x.MatchLdsfld(typeof(ContagiousItemManager).GetField(nameof(ContagiousItemManager.originalToTransformed),ReflectionHelper.AllFlags)),
+            x => x.MatchLdarg(1),
+            x => x.MatchLdelemI4());
+
+        if(ILFound){
+            c.Emit(OpCodes.Pop);
+            c.Emit(OpCodes.Ldarg,0);
+            c.Emit(OpCodes.Ldarg,1);
+            c.EmitDelegate<Func<Inventory,ItemIndex,ItemIndex>>((inventory,pureItem) =>{
+                List<ItemIndex> possibilities = inventory.itemAcquisitionOrder.Where(item => ContagiousItemManager.GetOriginalItemIndex(item) == pureItem).ToList();
+                    switch(contagionPriority.Value){
+                        case ContagionPriority.First:
+                          return possibilities.First();
+                        case ContagionPriority.Last:
+                          return possibilities.Last();
+                        case ContagionPriority.Alternate:
+                          var dict = alternateTracker.GetOrCreateValue(inventory);
+                          if(!dict.ContainsKey(pureItem))
+                            dict.Add(pureItem,0);
+                          return possibilities[(dict[pureItem]++)%(possibilities.Count)];
+                        case ContagionPriority.Rarest:
+                          possibilities.Sort((item,item2) => ItemCatalog.GetItemDef(item).tier.CompareTo(ItemCatalog.GetItemDef(item2).tier));
+                          return possibilities.Last();
+                        case ContagionPriority.Random:
+                          if(voidRNG == null){
+                            voidRNG = new Xoroshiro128Plus(RoR2.Run.instance.stageRng.nextUlong);
+                          }
+                          return possibilities[voidRNG.RangeInt(0,possibilities.Count)];
+                        default:      
+                          return ContagiousItemManager.originalToTransformed[(int)pureItem];
+                    }
+            });
+        }
+    }
+
+  
+}

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -2,6 +2,7 @@ using BepInEx;
 using RoR2;
 using RoR2BepInExPack.LegacyAssetSystem;
 using RoR2BepInExPack.VanillaFixes;
+using RoR2BepInExPack.ModCompatibility;
 
 namespace RoR2BepInExPack;
 
@@ -30,6 +31,8 @@ public class RoR2BepInExPack : BaseUnityPlugin
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
+
+        FixMultiCorrupt.Init(Config);
     }
 
     private void OnEnable()
@@ -41,6 +44,8 @@ public class RoR2BepInExPack : BaseUnityPlugin
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
+    
+        FixMultiCorrupt.Enable();
     }
 
     private void OnDisable()
@@ -52,6 +57,8 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferSearchableAttribute.Disable();
         SaferAchievementManager.Disable();
         ILLine.Disable();
+
+        FixMultiCorrupt.Disable();
     }
 
     private void OnDestroy()
@@ -63,5 +70,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferSearchableAttribute.Destroy();
         SaferAchievementManager.Destroy();
         ILLine.Destroy();
+
+        FixMultiCorrupt.Destroy();
     }
 }


### PR DESCRIPTION
Fixes the issue where multiple corruption targets for an item are present,provides the following methods via config to determine how to decide who gets the new stack:
Random -> (Default Option) picks randomly
First -> Oldest Target Picked Up
Last -> Newest Target Picked Up
Rarest -> Rarest Target Picked Up ( falls back to Newest on ambiguity)
Alternate -> All targets get a turn in acquisition order

Put under ModCompatibility because discussion pointed out that it wasn't actually 'fixing' any vanilla issues(due to vanilla not containing any multiple target corruptions). Pluripotent Larva prefers results you already have and applies the same selection method over the full list of possible corruptions instead if you don't have any.