### PR TITLE
Global Elite Ramp Solution

### DIFF
--- a/RoR2BepInExPack/GlobalEliteRampSolution/EliteRampManager.cs
+++ b/RoR2BepInExPack/GlobalEliteRampSolution/EliteRampManager.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using RoR2;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace RoR2BepInExPack.GlobalEliteRampSolution;
+
+public static class EliteRampManager
+{
+    internal static Dictionary<EliteDef, Texture2D> eliteToTexture = new();
+    private static ILHook ilHook;
+    private static Texture2D vanillaEliteRamp;
+    private static int EliteRampPropertyID => Shader.PropertyToID("_EliteRamp");
+    public static void AddRamp(EliteDef def, Texture2D ramp)
+    {
+        try
+        {
+            if (eliteToTexture.ContainsKey(def))
+                throw new InvalidOperationException($"Cannot add EliteDef {def} as its already in the dictionary");
+
+            eliteToTexture.Add(def, ramp);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+        }
+    }
+    private static void ILUpdateRampProperly(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        c.GotoNext(MoveType.After,
+            x => x.MatchLdarg(0),
+            x => x.MatchLdfld<CharacterModel>(nameof(CharacterModel.propertyStorage)),
+            x => x.MatchLdsfld(typeof(CommonShaderProperties), nameof(CommonShaderProperties._EliteIndex)));
+
+        c.GotoNext(MoveType.After,
+            x => x.MatchCallOrCallvirt<MaterialPropertyBlock>(nameof(MaterialPropertyBlock.SetFloat)));
+
+        c.Emit(OpCodes.Ldarg, 0);
+        c.EmitDelegate(UpdateRampProperly);
+    }
+
+    private static void UpdateRampProperly(CharacterModel charModel)
+    {
+        EliteDef myEliteDef = EliteCatalog.GetEliteDef(charModel.myEliteIndex);
+        if(eliteToTexture.TryGetValue(myEliteDef, out var ramp))
+        {
+            charModel.propertyStorage.SetTexture(EliteRampPropertyID, ramp);
+            return;
+        }
+
+        charModel.propertyStorage.SetTexture(EliteRampPropertyID, vanillaEliteRamp);
+    }
+
+    #region Init,Enable,Disable,Destroy
+    internal static async void Init()
+    {
+        var hookConfig = new HookConfig() { ManualApply = true };
+        ilHook = new ILHook(typeof(CharacterModel).GetMethod(nameof(CharacterModel.UpdateMaterials)), ILUpdateRampProperly);
+
+        vanillaEliteRamp = await Addressables.LoadAssetAsync<Texture2D>("RoR2/Base/Common/ColorRamps/texRampElites.psd").Task;
+    }
+
+    internal static void Enable()
+    {
+        ilHook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        ilHook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        ilHook.Free();
+    }
+    #endregion
+}

--- a/RoR2BepInExPack/GlobalEliteRampSolution/EliteRampManager.cs
+++ b/RoR2BepInExPack/GlobalEliteRampSolution/EliteRampManager.cs
@@ -80,12 +80,19 @@ public static class EliteRampManager
     #region Init,Enable,Disable,Destroy
     internal static async void Init()
     {
-        RoR2Application.onLoad += SetupDictionary;
+        try
+        {
+            RoR2Application.onLoad += SetupDictionary;
         
-        var hookConfig = new HookConfig() { ManualApply = true };
-        ilHook = new ILHook(typeof(CharacterModel).GetMethod(nameof(CharacterModel.UpdateMaterials), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance), ILUpdateRampProperly);
+            var hookConfig = new HookConfig() { ManualApply = true };
+            ilHook = new ILHook(typeof(CharacterModel).GetMethod(nameof(CharacterModel.UpdateMaterials), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance), ILUpdateRampProperly);
 
-        vanillaEliteRamp = await Addressables.LoadAssetAsync<Texture2D>("RoR2/Base/Common/ColorRamps/texRampElites.psd").Task;
+            vanillaEliteRamp = await Addressables.LoadAssetAsync<Texture2D>("RoR2/Base/Common/ColorRamps/texRampElites.psd").Task;
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"{nameof(EliteRampManager)} failed to initialize: {ex}");
+        }
     }
 
     internal static void Enable()

--- a/RoR2BepInExPack/LegacyAssetSystem/LegacyResourcesDetours.cs
+++ b/RoR2BepInExPack/LegacyAssetSystem/LegacyResourcesDetours.cs
@@ -29,15 +29,22 @@ internal static class LegacyResourcesDetours
 
     internal static void Init()
     {
-        _legacyResourcesAPILoad = typeof(LegacyResourcesAPI).GetMethod(nameof(LegacyResourcesAPI.Load), ReflectionHelper.AllFlags);
+        try
+        {
+            _legacyResourcesAPILoad = typeof(LegacyResourcesAPI).GetMethod(nameof(LegacyResourcesAPI.Load), ReflectionHelper.AllFlags);
 
-        var resourcesLoadDetourConfig = new NativeDetourConfig { ManualApply = true };
-        _resourcesLoadDetour = new NativeDetour(
-                typeof(Resources).GetMethod(nameof(Resources.Load), ReflectionHelper.AllFlags, null, new[] { typeof(string), typeof(Type) }, null),
-                typeof(LegacyResourcesDetours).GetMethod(nameof(OnResourcesLoad), ReflectionHelper.AllFlags),
-                resourcesLoadDetourConfig
-            );
-        _origLoad = _resourcesLoadDetour.GenerateTrampoline<ResourcesLoadDefinition>();
+            var resourcesLoadDetourConfig = new NativeDetourConfig { ManualApply = true };
+            _resourcesLoadDetour = new NativeDetour(
+                    typeof(Resources).GetMethod(nameof(Resources.Load), ReflectionHelper.AllFlags, null, new[] { typeof(string), typeof(Type) }, null),
+                    typeof(LegacyResourcesDetours).GetMethod(nameof(OnResourcesLoad), ReflectionHelper.AllFlags),
+                    resourcesLoadDetourConfig
+                );
+            _origLoad = _resourcesLoadDetour.GenerateTrampoline<ResourcesLoadDefinition>();
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"{nameof(LegacyResourcesDetours)} failed to initialize: {ex}");
+        }
     }
 
     internal static void Enable()

--- a/RoR2BepInExPack/LegacyAssetSystem/LegacyShaderDetours.cs
+++ b/RoR2BepInExPack/LegacyAssetSystem/LegacyShaderDetours.cs
@@ -1,4 +1,5 @@
-﻿using MonoMod.RuntimeDetour;
+﻿using System;
+using MonoMod.RuntimeDetour;
 using RoR2;
 using RoR2BepInExPack.Reflection;
 using UnityEngine;
@@ -13,13 +14,20 @@ internal static class LegacyShaderDetours
 
     internal static void Init()
     {
-        var shaderFindDetourConfig = new NativeDetourConfig { ManualApply = true };
-        _shaderFindDetour = new NativeDetour(
-                typeof(Shader).GetMethod(nameof(Shader.Find), ReflectionHelper.AllFlags, null, new[] { typeof(string) }, null),
-                typeof(LegacyShaderDetours).GetMethod(nameof(OnShaderFind), ReflectionHelper.AllFlags),
-                shaderFindDetourConfig
-            );
-        _origFind = _shaderFindDetour.GenerateTrampoline<ShaderFindDefinition>();
+        try
+        {
+            var shaderFindDetourConfig = new NativeDetourConfig { ManualApply = true };
+            _shaderFindDetour = new NativeDetour(
+                    typeof(Shader).GetMethod(nameof(Shader.Find), ReflectionHelper.AllFlags, null, new[] { typeof(string) }, null),
+                    typeof(LegacyShaderDetours).GetMethod(nameof(OnShaderFind), ReflectionHelper.AllFlags),
+                    shaderFindDetourConfig
+                );
+            _origFind = _shaderFindDetour.GenerateTrampoline<ShaderFindDefinition>();
+        }
+        catch(Exception ex)
+        {
+            Log.Error($"{nameof(LegacyShaderDetours)} failed to initialize: {ex}");
+        }
     }
 
     internal static void Enable()

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -2,6 +2,7 @@ using BepInEx;
 using RoR2;
 using RoR2BepInExPack.LegacyAssetSystem;
 using RoR2BepInExPack.VanillaFixes;
+using RoR2BepInExPack.GlobalEliteRampSolution;
 
 namespace RoR2BepInExPack;
 
@@ -30,6 +31,8 @@ public class RoR2BepInExPack : BaseUnityPlugin
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
+
+        EliteRampManager.Init();
     }
 
     private void OnEnable()
@@ -41,6 +44,8 @@ public class RoR2BepInExPack : BaseUnityPlugin
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
+
+        EliteRampManager.Enable();
     }
 
     private void OnDisable()
@@ -52,6 +57,8 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferSearchableAttribute.Disable();
         SaferAchievementManager.Disable();
         ILLine.Disable();
+
+        EliteRampManager.Disable();
     }
 
     private void OnDestroy()
@@ -63,5 +70,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferSearchableAttribute.Destroy();
         SaferAchievementManager.Destroy();
         ILLine.Destroy();
+
+        EliteRampManager.Destroy();
     }
 }

--- a/RoR2BepInExPack/UnityEngineHooks/ILLine.cs
+++ b/RoR2BepInExPack/UnityEngineHooks/ILLine.cs
@@ -14,8 +14,15 @@ internal class ILLine
 
     internal static void Init()
     {
-        var hookConfig = new HookConfig() { ManualApply = true };
-        _hook = new ILHook(typeof(StackTrace).GetMethod("AddFrames", ReflectionHelper.AllFlags), new ILContext.Manipulator(ShowILLine));
+        try
+        {
+            var hookConfig = new HookConfig() { ManualApply = true };
+            _hook = new ILHook(typeof(StackTrace).GetMethod("AddFrames", ReflectionHelper.AllFlags), new ILContext.Manipulator(ShowILLine));
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"{nameof(ILLine)} failed to initialize: {ex}");
+        }
     }
 
     internal static void Enable()

--- a/RoR2BepInExPack/VanillaFixes/FixConsoleLog.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixConsoleLog.cs
@@ -1,4 +1,5 @@
-﻿using MonoMod.RuntimeDetour;
+﻿using System;
+using MonoMod.RuntimeDetour;
 using RoR2;
 using RoR2BepInExPack.Reflection;
 
@@ -10,12 +11,19 @@ internal class FixConsoleLog
 
     internal static void Init()
     {
-        var hookConfig = new HookConfig() { ManualApply = true };
-        _hook = new Hook(
-                        typeof(UnitySystemConsoleRedirector).GetMethod(nameof(UnitySystemConsoleRedirector.Redirect), ReflectionHelper.AllFlags),
-                        typeof(FixConsoleLog).GetMethod(nameof(FixConsoleLog.DoNothing), ReflectionHelper.AllFlags),
-                        hookConfig
-                    );
+        try
+        {
+            var hookConfig = new HookConfig() { ManualApply = true };
+            _hook = new Hook(
+                            typeof(UnitySystemConsoleRedirector).GetMethod(nameof(UnitySystemConsoleRedirector.Redirect), ReflectionHelper.AllFlags),
+                            typeof(FixConsoleLog).GetMethod(nameof(FixConsoleLog.DoNothing), ReflectionHelper.AllFlags),
+                            hookConfig
+                        );
+        }
+        catch(Exception ex)
+        {
+            Log.Error($"{nameof(FixConsoleLog)} failed to initialize: {ex}");
+        }
     }
 
     internal static void Enable()

--- a/RoR2BepInExPack/VanillaFixes/SaferAchievementManager.cs
+++ b/RoR2BepInExPack/VanillaFixes/SaferAchievementManager.cs
@@ -23,15 +23,22 @@ public class SaferAchievementManager
 
     internal static void Init()
     {
-        var hookConfig = new HookConfig() { ManualApply = true };
+        try
+        {
+            var hookConfig = new HookConfig() { ManualApply = true };
 
-        _hook = new Hook(
-                        typeof(AchievementManager).GetMethod(nameof(AchievementManager.CollectAchievementDefs), ReflectionHelper.AllFlags),
-                        typeof(SaferAchievementManager).GetMethod(nameof(SaferAchievementManager.SaferCollectAchievementDefs), ReflectionHelper.AllFlags),
-                        hookConfig
-                    );
+            _hook = new Hook(
+                            typeof(AchievementManager).GetMethod(nameof(AchievementManager.CollectAchievementDefs), ReflectionHelper.AllFlags),
+                            typeof(SaferAchievementManager).GetMethod(nameof(SaferAchievementManager.SaferCollectAchievementDefs), ReflectionHelper.AllFlags),
+                            hookConfig
+                        );
 
-        _achievementManagerOnAchievementsRegisteredFieldInfo = typeof(AchievementManager).GetField(nameof(AchievementManager.onAchievementsRegistered), ReflectionHelper.AllFlags);
+            _achievementManagerOnAchievementsRegisteredFieldInfo = typeof(AchievementManager).GetField(nameof(AchievementManager.onAchievementsRegistered), ReflectionHelper.AllFlags);
+        }
+        catch(Exception ex)
+        {
+            Log.Error($"{nameof(SaferAchievementManager)} failed to initialize: {ex}");
+        }
     }
 
     internal static void Enable()

--- a/RoR2BepInExPack/VanillaFixes/SaferSearchableAttribute.cs
+++ b/RoR2BepInExPack/VanillaFixes/SaferSearchableAttribute.cs
@@ -21,19 +21,26 @@ internal class SaferSearchableAttribute
 
     internal static void Init()
     {
-        var hookConfig = new HookConfig() { ManualApply = true };
+        try
+        {
+            var hookConfig = new HookConfig() { ManualApply = true };
 
-        _saferCctorHook = new Hook(
-                        typeof(SearchableAttribute).GetMethod(nameof(SearchableAttribute.ScanAllAssemblies), ReflectionHelper.AllFlags),
-                        typeof(SaferSearchableAttribute).GetMethod(nameof(SaferSearchableAttribute.TryCatchEachLoopIteration), ReflectionHelper.AllFlags),
-                        hookConfig
-                    );
+            _saferCctorHook = new Hook(
+                            typeof(SearchableAttribute).GetMethod(nameof(SearchableAttribute.ScanAllAssemblies), ReflectionHelper.AllFlags),
+                            typeof(SaferSearchableAttribute).GetMethod(nameof(SaferSearchableAttribute.TryCatchEachLoopIteration), ReflectionHelper.AllFlags),
+                            hookConfig
+                        );
 
-        _deterministicCctorTimingHook = new Hook(
-                        typeof(RoR2.RoR2Application).GetMethod(nameof(RoR2.RoR2Application.OnLoad), ReflectionHelper.AllFlags),
-                        typeof(SaferSearchableAttribute).GetMethod(nameof(SaferSearchableAttribute.DeterministicCctorTiming), ReflectionHelper.AllFlags),
-                        hookConfig
-                    );
+            _deterministicCctorTimingHook = new Hook(
+                            typeof(RoR2.RoR2Application).GetMethod(nameof(RoR2.RoR2Application.OnLoad), ReflectionHelper.AllFlags),
+                            typeof(SaferSearchableAttribute).GetMethod(nameof(SaferSearchableAttribute.DeterministicCctorTiming), ReflectionHelper.AllFlags),
+                            hookConfig
+                        );
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"{nameof(SaferSearchableAttribute)} failed to initialize: {ex}");
+        }
     }
 
     internal static void Enable()


### PR DESCRIPTION
The global elite ramp solution is a class that allows for easy addition and managing of the Elite Ramps system that risk of rain 2 has, which is notoriously difficult to expand/extend past the vanilla elites.

The global elite ramp soltuion consists of a single class called EliteRampManager, which ILHooks onto the CharacterModel.UpdateMaterials method for setting the ramp manually to the material's property block.

The elite ramp manager has a single public method for adding a new ramp, which is EliteRampManager.AddRamp(EliteDef, Texture2D). once RoR2Application.OnLoad is invoked, the elite ramp manager creates a dictionary from the addeed eliteDef & ramp tuples.