### PR TITLE
VanillaFixes: Add fix for log spam on some deaths.

### DIFF
--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -28,6 +28,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferAchievementManager.Init();
         SaferSearchableAttribute.Init();
         FixConsoleLog.Init();
+        FixDeathAnimLog.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -41,6 +42,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferAchievementManager.Enable();
         SaferSearchableAttribute.Enable();
         FixConsoleLog.Enable();
+        FixDeathAnimLog.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -55,6 +57,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        FixDeathAnimLog.Disable();
         FixConsoleLog.Disable();
         SaferSearchableAttribute.Disable();
         SaferAchievementManager.Disable();
@@ -68,6 +71,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        FixDeathAnimLog.Destroy();
         FixConsoleLog.Destroy();
         SaferSearchableAttribute.Destroy();
         SaferAchievementManager.Destroy();

--- a/RoR2BepInExPack/VanillaFixes/FixDeathAnimLog.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixDeathAnimLog.cs
@@ -1,0 +1,72 @@
+
+using MonoMod.RuntimeDetour;
+using MonoMod.Cil;
+using EntityStates;
+using RoR2BepInExPack.Reflection;
+using System;
+using Mono.Cecil.Cil;
+using UnityEngine;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+
+// GenericCharacterDeath queues up a death animation for any present animator,leading to unnecessary log output
+// Fix: Ensure a death animation exists before trying to play it
+internal class FixDeathAnimLog
+{
+    private static ILHook _ilHook;
+
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig() { ManualApply = true };
+        _ilHook = new ILHook(
+                    typeof(GenericCharacterDeath).GetMethod(nameof(GenericCharacterDeath.PlayDeathAnimation),ReflectionHelper.AllFlags),
+                    FixLackingAnim,
+                    ref ilHookConfig
+                );
+    }
+
+    internal static void Enable()
+    {
+        _ilHook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _ilHook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _ilHook.Free();
+    }
+
+    private static void FixLackingAnim(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        ILLabel label = c.DefineLabel();
+        bool ILFound = c.TryGotoNext(MoveType.After,
+            x => x.MatchLdloc(0),
+            x => x.MatchCallOrCallvirt(out _),
+            x => x.MatchBrfalse(out label));
+
+        if (ILFound)
+        {
+            c.Emit(OpCodes.Ldloc_0);
+            c.EmitDelegate<Func<Animator,bool>>((anim) => {
+                for(int i = 0; i < anim.layerCount; i++){
+                    if(anim.HasState(i,Animator.StringToHash("Death"))){
+                        return true;
+                    }
+                }
+              return false;
+            });
+            c.Emit(OpCodes.Brfalse,label);
+        }
+        else
+        {
+            Log.Error("FixDeathAnimLog TryGotoNext failed, not applying patch");
+        }
+    }
+}


### PR DESCRIPTION
GenericCharacterDeath queues up a death animation for any present animator,leading to unnecessary log output.
This gets quite spammy when testing things,and is just a general source of log clutter for something that would be visibly noticeable if it was actually an issue you cared about.
Thus: Fix: Ensure a death animation exists before trying to play it