### PR TITLE
Skip "GetItemDef return null" error on modded BaseItemBodyBehaviors

### DIFF
--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -31,6 +31,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixDeathAnimLog.Init();
         FixNullBone.Init();
         FixExtraGameModesMenu.Init();
+        FixItemDefReturnedNullLog.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -47,6 +48,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixDeathAnimLog.Enable();
         FixNullBone.Enable();
         FixExtraGameModesMenu.Enable();
+        FixItemDefReturnedNullLog.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -61,6 +63,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        FixItemDefReturnedNullLog.Disable();
         FixExtraGameModesMenu.Disable();
         FixNullBone.Disable();
         FixDeathAnimLog.Disable();
@@ -77,6 +80,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        FixItemDefReturnedNullLog.Destroy();
         FixExtraGameModesMenu.Destroy();
         FixNullBone.Destroy();
         FixDeathAnimLog.Destroy();

--- a/RoR2BepInExPack/VanillaFixes/FixItemDefReturnedNullLog.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixItemDefReturnedNullLog.cs
@@ -1,0 +1,70 @@
+
+using MonoMod.RuntimeDetour;
+using MonoMod.Cil;
+using EntityStates;
+using RoR2BepInExPack.Reflection;
+using System;
+using Mono.Cecil.Cil;
+using UnityEngine;
+using RoR2.Items;
+using System.Reflection;
+using RoR2;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+// BaseItemBodyBehavior logs targeted methods returning a null ItemDef as an error when this is usually intentional for modded item behaviors 
+// Fix: Skip logging the error if the item behavior is not from RoR2
+internal class FixItemDefReturnedNullLog
+{
+    private static ILHook _ilHook;
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig() { ManualApply = true };
+        _ilHook = new ILHook(
+                    typeof(BaseItemBodyBehavior).GetMethod(nameof(BaseItemBodyBehavior.Init),ReflectionHelper.AllFlags),
+                    SkipModdedReturnedNullErrors,
+                    ref ilHookConfig
+                );
+    }
+    internal static void Enable()
+    {
+        _ilHook.Apply();
+    }
+    internal static void Disable()
+    {
+        _ilHook.Undo();
+    }
+    internal static void Destroy()
+    {
+        _ilHook.Free();
+    }
+    private static void SkipModdedReturnedNullErrors(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        ILLabel breakLabel = c.DefineLabel();
+        int locMethodIndex = -1;
+        bool ILFound = c.TryGotoNext(MoveType.After,
+            x => x.MatchBr(out breakLabel),
+            x => x.MatchLdloc(out locMethodIndex),
+            x => x.MatchLdnull(),
+            x => x.MatchCallOrCallvirt<Array>(nameof(Array.Empty)),
+            x => x.MatchCallOrCallvirt<MethodBase>(nameof(MethodBase.Invoke)),
+            x => x.MatchCastclass<ItemDef>()
+            ) && c.TryGotoNext(MoveType.After,
+            x => x.MatchCallOrCallvirt<UnityEngine.Object>("op_Implicit"),
+            x => x.MatchBrtrue(out _)
+            );
+
+        if (ILFound)
+        {
+            c.Emit(OpCodes.Ldloc, locMethodIndex);
+            c.EmitDelegate<Func<MethodInfo, bool>>((method) => method != null && method.DeclaringType.Assembly != typeof(BaseItemBodyBehavior).Assembly);
+            c.Emit(OpCodes.Brtrue, breakLabel);
+        }
+        else
+        {
+            Log.Error("SkipModdedReturnedNullErrors TryGotoNext failed, not applying patch");
+        }
+    }
+}


### PR DESCRIPTION
Implements #11 if it would be a good fit for RoR2BepInExPack. See #11 for details on the fix. TLDR; BaseItemBodyBehavior logs errors that are almost always irrelevant to mods. 