### PR TITLE
Fix ProjectileCatalog Projectile Limit Error

### DIFF
--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -31,6 +31,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixDeathAnimLog.Init();
         FixNullBone.Init();
         FixExtraGameModesMenu.Init();
+        FixProjectileCatalogLimitError.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -47,6 +48,8 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixDeathAnimLog.Enable();
         FixNullBone.Enable();
         FixExtraGameModesMenu.Enable();
+        FixProjectileCatalogLimitError.Enable();
+
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -61,6 +64,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        FixProjectileCatalogLimitError.Disable();
         FixExtraGameModesMenu.Disable();
         FixNullBone.Disable();
         FixDeathAnimLog.Disable();
@@ -77,6 +81,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        FixProjectileCatalogLimitError.Destroy();
         FixExtraGameModesMenu.Destroy();
         FixNullBone.Destroy();
         FixDeathAnimLog.Destroy();

--- a/RoR2BepInExPack/VanillaFixes/FixProjectileCatalogLimitError.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixProjectileCatalogLimitError.cs
@@ -1,0 +1,65 @@
+
+using MonoMod.RuntimeDetour;
+using MonoMod.Cil;
+using EntityStates;
+using RoR2BepInExPack.Reflection;
+using System;
+using Mono.Cecil.Cil;
+using UnityEngine;
+using RoR2.Items;
+using System.Reflection;
+using RoR2;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+// The ProjectileCatalog logs an error if more than 256 projectiles are registered, despite the actual limit being much higher.
+// Fix: Update the projectile limit to prevent the misleading error
+internal class FixProjectileCatalogLimitError
+{
+    private static ILHook _ilHook;
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig() { ManualApply = true };
+        _ilHook = new ILHook(
+                    typeof(ProjectileCatalog).GetMethod(nameof(ProjectileCatalog.SetProjectilePrefabs), ReflectionHelper.AllFlags),
+                    IncreaseCatalogLimit,
+                    ref ilHookConfig
+                );
+    }
+    internal static void Enable()
+    {
+        _ilHook.Apply();
+    }
+    internal static void Disable()
+    {
+        _ilHook.Undo();
+    }
+    internal static void Destroy()
+    {
+        _ilHook.Free();
+    }
+    private static void IncreaseCatalogLimit(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        int locLimitIndex = -1;
+        bool ILFound = c.TryGotoNext(MoveType.Before,
+            x => x.MatchLdcI4(out _),
+            x => x.MatchStloc(out locLimitIndex),
+            x => x.MatchLdsfld(typeof(ProjectileCatalog).GetField(nameof(ProjectileCatalog.projectilePrefabs), ReflectionHelper.AllFlags)),
+            x => x.MatchLdlen(),
+            x => x.MatchConvI4(),
+            x => x.MatchLdloc(locLimitIndex),
+            x => x.MatchBle(out _)
+            );
+
+        if (ILFound)
+        {
+            c.Next.Operand = int.MaxValue;
+        }
+        else
+        {
+            Log.Error("IncreaseCatalogLimit TryGotoNext failed, not applying patch");
+        }
+    }
+}


### PR DESCRIPTION
Addresses #4 by skipping the projectile limit check. Should prevent the inaccurate and confusing ProjectileCatalog error.