### PR TITLE
FixConVar patch

### DIFF
--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -12,7 +12,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
 {
     public const string PluginGUID = "___riskofthunder" + "." + PluginName;
     public const string PluginName = "RoR2BepInExPack";
-    public const string PluginVersion = "1.3.0";
+    public const string PluginVersion = "1.4.0";
 
     internal static PluginInfo pluginInfo;
 

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -14,8 +14,11 @@ public class RoR2BepInExPack : BaseUnityPlugin
     public const string PluginName = "RoR2BepInExPack";
     public const string PluginVersion = "1.3.0";
 
+    internal static PluginInfo pluginInfo;
+
     private void Awake()
     {
+        pluginInfo = Info;
         Log.Init(Logger);
 
         RoR2Application.isModded = true;
@@ -30,6 +33,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferAchievementManager.Init();
         SaferSearchableAttribute.Init();
         FixConsoleLog.Init();
+        FixConVar.Init();
         FixDeathAnimLog.Init();
         FixNullBone.Init();
         FixExtraGameModesMenu.Init();
@@ -47,6 +51,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferAchievementManager.Enable();
         SaferSearchableAttribute.Enable();
         FixConsoleLog.Enable();
+        FixConVar.Enable();
         FixDeathAnimLog.Enable();
         FixNullBone.Enable();
         FixExtraGameModesMenu.Enable();
@@ -68,6 +73,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixNullBone.Disable();
         FixDeathAnimLog.Disable();
         FixConsoleLog.Disable();
+        FixConVar.Disable();
         SaferSearchableAttribute.Disable();
         SaferAchievementManager.Disable();
         AutoCatchReflectionTypeLoadException.Disable();
@@ -85,6 +91,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixNullBone.Destroy();
         FixDeathAnimLog.Destroy();
         FixConsoleLog.Destroy();
+        FixConVar.Destroy();
         SaferSearchableAttribute.Destroy();
         SaferAchievementManager.Destroy();
         AutoCatchReflectionTypeLoadException.Destroy();

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -14,11 +14,8 @@ public class RoR2BepInExPack : BaseUnityPlugin
     public const string PluginName = "RoR2BepInExPack";
     public const string PluginVersion = "1.4.0";
 
-    internal static PluginInfo pluginInfo;
-
     private void Awake()
     {
-        pluginInfo = Info;
         Log.Init(Logger);
 
         RoR2Application.isModded = true;

--- a/RoR2BepInExPack/VanillaFixes/FixConVar.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixConVar.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using RoR2BepInExPack.Reflection;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+// Convars in vanilla only check for ConVars in the base RoR2 Assembly, which means ConVars cant be used
+// by other assemblies
+// Fix: Make it so all assemblies are scanned for ConVarss
+internal static class FixConVar
+{
+    private static ILHook _ilHook;
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig { ManualApply = true };
+        _ilHook = new ILHook(typeof(RoR2.Console).GetMethod(nameof(RoR2.Console.InitConVars), ReflectionHelper.AllFlags),
+            ScanAllAssemblies,
+            ref ilHookConfig);
+    }
+    internal static void Enable()
+    {
+        _ilHook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _ilHook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _ilHook.Free();
+    }
+
+    private static void ScanAllAssemblies(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        bool ilFound = c.TryGotoNext(MoveType.After, x => x.MatchLdtoken(out _),
+            x => x.MatchCallOrCallvirt<Type>(nameof(Type.GetTypeFromHandle)),
+            x => x.MatchCallOrCallvirt<Type>("get_Assembly"),
+            x => x.MatchCallOrCallvirt<Assembly>(nameof(Assembly.GetTypes)));
+
+        if (ilFound)
+        {
+            c.EmitDelegate(LoadAllConVars);
+        }
+        else
+        {
+            Log.Error("FixConVar TryGotoNext failed, not applying patch");
+        }
+    }
+
+    //We cant load r2api's types because EmbeddedResources causes mono to commit sudoku and die
+    private static Type[] LoadAllConVars(Type[] dontCareTypes)
+    {
+        return AppDomain.CurrentDomain.GetAssemblies().Where(ass => !ass.FullName.Contains("R2API") && ass.GetCustomAttribute<HG.Reflection.SearchableAttribute.OptInAttribute>() != null).SelectMany(ass => ass.GetTypes()).ToArray();
+    }
+}


### PR DESCRIPTION
This PR fixes the issue present on vanilla RoR2 where the Console only checks for ConVars (BaseConVar, IntConVar, etc) on the RoR2 assembly instead of searching thru the entire app domain.

This is done by just filtering for assemblies that OptIn for the SearchableAttribute found under the HG.Reflection namespace.

As a side bonus, this effectively makes R2API's CommandHelper completely obsolete 🎉