### PR TITLE
Handle Non-existent Expansion + Expose Logspam + Nonlethal kills with 1  max hp

### DIFF
--- a/RoR2BepInExPack/ModCompatibility/FixNullEntitlement.cs
+++ b/RoR2BepInExPack/ModCompatibility/FixNullEntitlement.cs
@@ -1,0 +1,70 @@
+using MonoMod.RuntimeDetour;
+using MonoMod.Cil;
+using EntityStates;
+using RoR2BepInExPack.Reflection;
+using System;
+using Mono.Cecil.Cil;
+using UnityEngine;
+using RoR2.EntitlementManagement;
+
+namespace RoR2BepInExPack.ModCompatibility;
+
+
+// Mods don't often have their own entitlement defs because creating them is unnecessarily complex,but the game assumes they exist if expansions are involved.
+// Fix: Everyone is entitled to having a Nothing.
+internal class FixNullEntitlement
+{
+    private static ILHook _localILHook;
+    private static ILHook _networkILHook;
+
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig() { ManualApply = true };
+        _localILHook = new ILHook(
+                    typeof(BaseUserEntitlementTracker<RoR2.LocalUser>).GetMethod(nameof(BaseUserEntitlementTracker<RoR2.LocalUser>.UserHasEntitlement),ReflectionHelper.AllFlags),
+                    FixEntitledCheck,
+                    ref ilHookConfig
+                );
+        _networkILHook = new ILHook(
+                    typeof(BaseUserEntitlementTracker<RoR2.NetworkUser>).GetMethod(nameof(BaseUserEntitlementTracker<RoR2.NetworkUser>.UserHasEntitlement),ReflectionHelper.AllFlags),
+                    FixEntitledCheck,
+                    ref ilHookConfig
+                );
+    }
+
+    internal static void Enable()
+    {
+        _localILHook.Apply();
+        _networkILHook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _localILHook.Undo();
+        _networkILHook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _localILHook.Free();
+        _networkILHook.Free();
+    }
+
+    private static void FixEntitledCheck(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        bool ILFound = c.TryGotoNext(
+            x => x.MatchLdstr("entitlementDef"));
+
+        if (ILFound)
+        {
+            c.Emit(OpCodes.Ldc_I4_1);
+            c.Emit(OpCodes.Ret);
+        }
+        else
+        {
+            Log.Error("FixNullEntitlement TryGotoNext failed, not applying patch");
+        }
+    }
+}

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -38,6 +38,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferWWise.Init();
         FixNullEntitlement.Init();
         FixExposeLog.Init();
+        FixNonLethalOneHP.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -60,6 +61,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferWWise.Enable();
         FixNullEntitlement.Enable();
         FixExposeLog.Enable();
+        FixNonLethalOneHP.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -74,6 +76,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        FixNonLethalOneHP.Disable();
         FixExposeLog.Disable();
         FixNullEntitlement.Disable();
         SaferWWise.Disable();
@@ -96,6 +99,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        FixNonLethalOneHP.Destroy();
         FixExposeLog.Destroy();
         FixNullEntitlement.Destroy();
         SaferWWise.Destroy();

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -36,6 +36,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixExtraGameModesMenu.Init();
         FixProjectileCatalogLimitError.Init();
         SaferWWise.Init();
+        FixNullEntitlement.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -56,6 +57,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixExtraGameModesMenu.Enable();
         FixProjectileCatalogLimitError.Enable();
         SaferWWise.Enable();
+        FixNullEntitlement.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -70,6 +72,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        FixNullEntitlement.Disable();
         SaferWWise.Disable();
         FixProjectileCatalogLimitError.Disable();
         FixExtraGameModesMenu.Disable();
@@ -90,6 +93,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        FixNullEntitlement.Destroy();
         SaferWWise.Destroy();
         FixProjectileCatalogLimitError.Destroy();
         FixExtraGameModesMenu.Destroy();

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -12,7 +12,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
 {
     public const string PluginGUID = "___riskofthunder" + "." + PluginName;
     public const string PluginName = "RoR2BepInExPack";
-    public const string PluginVersion = "1.5.0";
+    public const string PluginVersion = "1.6.0";
 
     private void Awake()
     {

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -37,6 +37,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixProjectileCatalogLimitError.Init();
         SaferWWise.Init();
         FixNullEntitlement.Init();
+        FixExposeLog.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -58,6 +59,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixProjectileCatalogLimitError.Enable();
         SaferWWise.Enable();
         FixNullEntitlement.Enable();
+        FixExposeLog.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -72,6 +74,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        FixExposeLog.Disable();
         FixNullEntitlement.Disable();
         SaferWWise.Disable();
         FixProjectileCatalogLimitError.Disable();
@@ -93,6 +96,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        FixExposeLog.Destroy();
         FixNullEntitlement.Destroy();
         SaferWWise.Destroy();
         FixProjectileCatalogLimitError.Destroy();

--- a/RoR2BepInExPack/VanillaFixes/FixExposeLog.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixExposeLog.cs
@@ -1,0 +1,68 @@
+using MonoMod.RuntimeDetour;
+using MonoMod.Cil;
+using EntityStates;
+using RoR2BepInExPack.Reflection;
+using System;
+using Mono.Cecil.Cil;
+using UnityEngine;
+using RoR2;
+using static RoR2.RoR2Content;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+
+// Meaningless Logspam on any application of Expose.
+// Fix: Don't.
+internal class FixExposeLog
+{
+    private static ILHook _ilHook;
+
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig() { ManualApply = true };
+        _ilHook = new ILHook(
+                    typeof(HealthComponent).GetMethod(nameof(HealthComponent.TakeDamage),ReflectionHelper.AllFlags),
+                    FixAddingExpose,
+                    ref ilHookConfig
+                );
+    }
+
+    internal static void Enable()
+    {
+        _ilHook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _ilHook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _ilHook.Free();
+    }
+
+    private static void FixAddingExpose(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        ILLabel skipLabel = c.DefineLabel();
+        bool ILFound = c.TryGotoNext(
+                x => x.MatchLdarg(0),
+                x => x.MatchLdfld(out _),
+                x => x.MatchLdsfld(typeof(Buffs).GetField(nameof(Buffs.MercExpose))),
+                x => x.MatchCallOrCallvirt(typeof(CharacterBody).GetMethod("AddBuff",new Type[]{typeof(BuffDef)})));
+        c.MarkLabel(skipLabel);
+        ILFound &= c.TryGotoPrev(
+                x => x.MatchLdstr("Adding expose"));
+
+        if (ILFound)
+        {
+            c.Emit(OpCodes.Br,skipLabel);
+        }
+        else
+        {
+            Log.Error("FixExposeLog TryGotoNext failed, not applying patch");
+        }
+    }
+}

--- a/RoR2BepInExPack/VanillaFixes/FixNonLethalOneHP.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixNonLethalOneHP.cs
@@ -1,0 +1,65 @@
+using MonoMod.RuntimeDetour;
+using MonoMod.Cil;
+using EntityStates;
+using RoR2BepInExPack.Reflection;
+using System;
+using Mono.Cecil.Cil;
+using UnityEngine;
+using RoR2;
+using static RoR2.RoR2Content;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+
+// When the player has non zero but less than one health the game fumbles the float math and kills anyways. 
+// Fix: Check for positive health instead of >= 1,the emitted delegate to do so is a bit roundabout to keep the existing branch instructions happy.
+internal class FixNonLethalOneHP
+{
+    private static ILHook _ilHook;
+
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig() { ManualApply = true };
+        _ilHook = new ILHook(
+                    typeof(HealthComponent).GetMethod(nameof(HealthComponent.TakeDamage),ReflectionHelper.AllFlags),
+                    FixLethality,
+                    ref ilHookConfig
+                );
+    }
+
+    internal static void Enable()
+    {
+        _ilHook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _ilHook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _ilHook.Free();
+    }
+
+    private static void FixLethality(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        bool ILFound = c.TryGotoNext( MoveType.After,
+                x => x.MatchLdfld(typeof(HealthComponent).GetField(nameof(HealthComponent.health),ReflectionHelper.AllFlags)),
+                x => x.MatchLdcR4(1),
+                x => x.MatchBltUn(out _));
+
+        if (ILFound)
+        {
+            c.Index--;
+            c.Emit(OpCodes.Ldarg_0);
+            c.EmitDelegate<Func<float,HealthComponent,float>>((targetHealth,self) => (self.health > 0f) ? 0f : targetHealth); 
+        }
+        else
+        {
+            Log.Error("FixNonLethalOneHP TryGotoNext failed, not applying patch");
+        }
+    }
+}


### PR DESCRIPTION
- ModCompat: Handle expansions without entitlement :  Fixes #16 
 Mods don't often have their own entitlement defs because creating them is a huge pain,but the game assumes they exist if expansions are involved.
 Fix: Everyone is entitled to having a Nothing.
- VanillaFixes: Remove Expose Logspam : 
  The game prints an unnecessary line whenever expose is applied via the damage type
  Fix: Don't.
- VanillaFixes: Fix NonLethal damage still killing when you have 1 max hp
  TakeDamage has some emergent sketchy float math that seems to fail without reason when the body has 1 max hp,causing the nonlethal damage check to fail
  Fix: Insert a different check,the way it ended up is not too clear on first sight because the vanilla IL is set up slightly inconviniently. 