### PR TITLE
Fix RemoveOldestTimedBuff

### DIFF
--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -59,6 +59,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixExposeLog.Init();
         FixNonLethalOneHP.Init();
         FixRunScaling.Init();
+        FixCharacterBodyRemoveOldestTimedBuff.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -83,6 +84,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixExposeLog.Enable();
         FixNonLethalOneHP.Enable();
         FixRunScaling.Enable();
+        FixCharacterBodyRemoveOldestTimedBuff.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -97,6 +99,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        FixCharacterBodyRemoveOldestTimedBuff.Disable();
         FixRunScaling.Disable();
         FixNonLethalOneHP.Disable();
         FixExposeLog.Disable();
@@ -121,6 +124,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        FixCharacterBodyRemoveOldestTimedBuff.Destroy();
         FixRunScaling.Destroy();
         FixNonLethalOneHP.Destroy();
         FixExposeLog.Destroy();

--- a/RoR2BepInExPack/VanillaFixes/FixCharacterBodyRemoveOldestTimedBuff.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixCharacterBodyRemoveOldestTimedBuff.cs
@@ -1,0 +1,59 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using RoR2;
+using RoR2BepInExPack.Reflection;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+// CharacterBody.RemoveOldestTimedBuff doesn't remove a buff
+// if it's index in the CharacterBody.timedBuffs array is 0,
+// because of incorrect guard-clause
+// Fix: exit the method only if index is < 0.
+internal class FixCharacterBodyRemoveOldestTimedBuff
+{
+    private static ILHook _ilHook;
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig() { ManualApply = true };
+        _ilHook = new ILHook(
+            typeof(CharacterBody).GetMethod(nameof(CharacterBody.RemoveOldestTimedBuff), ReflectionHelper.AllFlags, null, new[] { typeof(BuffIndex) }, null),
+            FixRemoveOldestTimedBuff,
+            ref ilHookConfig
+        );
+    }
+
+    internal static void Enable()
+    {
+        _ilHook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _ilHook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _ilHook.Free();
+    }
+
+    private static void FixRemoveOldestTimedBuff(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        bool ILFound = c.TryGotoNext(MoveType.After,
+                x => x.MatchLdloc(1),
+                x => x.MatchLdcI4(0),
+                x => x.MatchBle(out _));
+
+        if (ILFound)
+        {
+            c.Previous.OpCode = OpCodes.Blt;
+        }
+        else
+        {
+            Log.Error("FixRemoveOldestTimedBuff TryGotoNext failed, not applying patch");
+        }
+    }
+}


### PR DESCRIPTION
Following conversation https://discord.com/channels/562704639141740588/562704639569428506/1111840966731628574
tl;dr; `RemoveOldestTimedBuff` doesn't work if the oldest buff has index 0 in body.timedBuffs array