### PR TITLE
Fix HasEffectiveAuthority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+-   **1.14.0**
+
+    -   Fix HasEffectiveAuthority for host players.
+
 -   **1.13.0**
 
     -   Better fix for stack overflow exception that does not require a native dll.

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -14,7 +14,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
 {
     public const string PluginGUID = "___riskofthunder" + "." + PluginName;
     public const string PluginName = "RoR2BepInExPack";
-    public const string PluginVersion = "1.13.0";
+    public const string PluginVersion = "1.14.0";
 
     private void Awake()
     {
@@ -66,6 +66,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixRunScaling.Init();
         FixCharacterBodyRemoveOldestTimedBuff.Init();
         FixDedicatedServerMaxPlayerCount.Init();
+        FixHasEffectiveAuthority.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -93,6 +94,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixRunScaling.Enable();
         FixCharacterBodyRemoveOldestTimedBuff.Enable();
         FixDedicatedServerMaxPlayerCount.Enable();
+        FixHasEffectiveAuthority.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -107,6 +109,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        FixHasEffectiveAuthority.Disable();
         FixDedicatedServerMaxPlayerCount.Disable();
         FixCharacterBodyRemoveOldestTimedBuff.Disable();
         FixRunScaling.Disable();
@@ -134,6 +137,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        FixHasEffectiveAuthority.Destroy();
         FixDedicatedServerMaxPlayerCount.Destroy();
         FixCharacterBodyRemoveOldestTimedBuff.Destroy();
         FixRunScaling.Destroy();

--- a/RoR2BepInExPack/UnityEngineHooks/FrankenMonoPrintStackOverflowException.cs
+++ b/RoR2BepInExPack/UnityEngineHooks/FrankenMonoPrintStackOverflowException.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/RoR2BepInExPack/VanillaFixes/FixHasEffectiveAuthority.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixHasEffectiveAuthority.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using RoR2;
+using RoR2BepInExPack.Reflection;
+using UnityEngine.Networking;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+/// <summary>
+/// On a server there is a short time when authority is not assigned yet the object should have authority.
+/// Which is the reason for Captain to sometimes not have supply beacon charges.
+/// HasEffectiveAuthority makes additional checks to see if object should have authority but not enough.
+/// fix: check if clientAuthorityOwner is of type ULocalConnectionToClient
+/// </summary>
+internal class FixHasEffectiveAuthority
+{
+    private static ILHook _ilHook;
+
+
+    internal static void Init()
+    {
+        var ilHookConfig = new ILHookConfig() { ManualApply = true };
+        _ilHook = new ILHook(
+            typeof(Util).GetMethod(nameof(Util.HasEffectiveAuthority), ReflectionHelper.AllFlags, null, [typeof(NetworkIdentity)], null),
+            FixHook,
+            ref ilHookConfig);
+    }
+
+    internal static void Enable()
+    {
+        _ilHook.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _ilHook.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _ilHook.Free();
+    }
+
+    private static void FixHook(ILContext il)
+    {
+        ILCursor c = new ILCursor(il);
+        var ILFound = c.TryGotoNext(MoveType.After,
+           x => x.MatchCallOrCallvirt<NetworkIdentity>("get_clientAuthorityOwner"),
+           x => x.MatchLdnull(),
+           x => x.MatchCeq());
+
+        if (ILFound)
+        {
+            c.Emit(OpCodes.Dup);
+            c.Emit(OpCodes.Brtrue, c.Next);
+            c.Emit(OpCodes.Pop);
+            c.Emit(OpCodes.Ldarg_0);
+            c.Emit<NetworkIdentity>(OpCodes.Callvirt, "get_clientAuthorityOwner");
+            c.Emit(OpCodes.Isinst, typeof(ULocalConnectionToClient));
+            c.Emit(OpCodes.Ldnull);
+            c.Emit(OpCodes.Ceq);
+            c.Emit(OpCodes.Ldc_I4_0);
+            c.Emit(OpCodes.Ceq);
+        }
+        else
+        {
+            Log.Error("FixHasEffectiveAuthority TryGotoNext failed, not applying patch");
+        }
+    }
+}

--- a/Thunderstore/manifest.json
+++ b/Thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RoR2BepInExPack",
-  "version_number": "1.13.0",
+  "version_number": "1.14.0",
   "website_url": "https://github.com/risk-of-thunder/RoR2BepInExPack",
   "description": "Simplify the modding ecosystem of Risk of Rain 2, making it easier for modders to create and maintain their mods while preventing harmful bugs.",
   "dependencies": []


### PR DESCRIPTION
I got a bug report for ProperSave that first run after you start a game if you load saved game with Captain he would get no supply beacon charges (I'm surprised it wasn't reported before, its very consistent).
Looking for answers I found that for a host authority sometimes asigned a bit later and the game uses Util.HasEffectiveAuthority to check for cases where an object should have authority while it doesn't. For clients on a server `clientAuthorityOwner` is `NetworkConnection`, while for host it's `ULocalConnectionToClient`so I added additional check:
From: `return NetworkServer.active && networkIdentity.clientAuthorityOwner == null;`
To: `return NetworkServer.active && (networkIdentity.clientAuthorityOwner == null || networkIdentity.clientAuthorityOwner is ULocalConnectionToClient);`
I added it as vanilla fix because it can affect not only ProperSave and not only Captain.