### PR TITLE
Fix a crash when exiting the game with some mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+-   **1.15.0**
+
+    -   Fix a crash when exiting the game with some mods.
+
 -   **1.14.0**
 
     -   Fix HasEffectiveAuthority for host players.

--- a/RoR2BepInExPack/NativeStructs/GameObjectStruct.cs
+++ b/RoR2BepInExPack/NativeStructs/GameObjectStruct.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace RoR2BepInExPack.NativeStructs
+{
+    /// <summary>
+    /// Part of a native struct for GameObject
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    public struct GameObjectStruct
+    {
+        [FieldOffset(0x30)]
+        public IntPtr componentsPtr;
+    }
+}

--- a/RoR2BepInExPack/UnityEngineHooks/DestroyGameObjectRecursiveNullCheck.cs
+++ b/RoR2BepInExPack/UnityEngineHooks/DestroyGameObjectRecursiveNullCheck.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using MonoMod.RuntimeDetour;
+using RoR2BepInExPack.NativeStructs;
+using RoR2BepInExPack.Utilities;
+
+namespace RoR2BepInExPack.UnityEngineHooks
+{
+    /// <summary>
+    /// <see cref="PreDestroyRecursiveNullCheck"/> for explanation.
+    /// Adds a null check to DestroyGameObjectRecursive native function.
+    /// </summary>
+    public class DestroyGameObjectRecursiveNullCheck
+    {
+        /// <summary>
+        /// Function offset inside UnityPlayer.dll
+        /// </summary>
+        private const long Offset = 0x78e4d0;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void DestroyGameObjectRecursiveDelegate(IntPtr gameObject, IntPtr batchDelete);
+
+        private static DestroyGameObjectRecursiveDelegate original;
+        private static NativeDetour _detour;
+
+        public static void Init(IntPtr baseAddress)
+        {
+            var hookPtr = Marshal.GetFunctionPointerForDelegate(new DestroyGameObjectRecursiveDelegate(OnDestroyGameObjectRecursive));
+
+            _detour = new NativeDetour(baseAddress.Add(Offset), hookPtr);
+            original = _detour.GenerateTrampolineWithRecursionSupport<DestroyGameObjectRecursiveDelegate>(15);
+        }
+
+        private static unsafe void OnDestroyGameObjectRecursive(IntPtr gameObject, IntPtr something)
+        {
+            var ptr = ((GameObjectStruct*)gameObject.ToPointer())->componentsPtr.ToInt64();
+            if (ptr == 0)
+            {
+                return;
+            }
+
+            original(gameObject, something);
+        }
+    }
+}

--- a/RoR2BepInExPack/UnityEngineHooks/FrankenMonoPrintStackOverflowException.cs
+++ b/RoR2BepInExPack/UnityEngineHooks/FrankenMonoPrintStackOverflowException.cs
@@ -38,6 +38,7 @@ internal unsafe static class FrankenMonoPrintStackOverflowException
 
         // now we test
 #if DEBUG
+        /*
         try
         {
             Recurse();
@@ -46,6 +47,7 @@ internal unsafe static class FrankenMonoPrintStackOverflowException
         {
             Log.Info("SOE fix applied");
         }
+        */
 #endif
     }
 

--- a/RoR2BepInExPack/UnityEngineHooks/PreDestroyRecursiveNullCheck.cs
+++ b/RoR2BepInExPack/UnityEngineHooks/PreDestroyRecursiveNullCheck.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using MonoMod.RuntimeDetour;
+using RoR2BepInExPack.NativeStructs;
+using RoR2BepInExPack.Utilities;
+
+namespace RoR2BepInExPack.UnityEngineHooks
+{
+    /// <summary>
+    /// Some mods add prefabs loaded from asset bundles directly as children
+    /// to runtime prefabs instantiated with PrefabsAPI.InstantiateClone.
+    /// And it seems like these prefabs are destroyed before runtime prefabs when the game is closing,
+    /// which results in a harmless, but certainly annoying crash.
+    /// Adds a null check to PreDestroyRecursive native function.
+    /// </summary>
+    public class PreDestroyRecursiveNullCheck
+    {
+        /// <summary>
+        /// Function offset inside UnityPlayer.dll
+        /// </summary>
+        private const long Offset = 0x78fea0;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void PreDestroyRecursiveDelegate(IntPtr gameObject, IntPtr destroyedObjectCount);
+
+        private static PreDestroyRecursiveDelegate original;
+        private static NativeDetour _detour;
+
+        public static void Init(IntPtr baseAddress)
+        {
+            var hookPtr = Marshal.GetFunctionPointerForDelegate(new PreDestroyRecursiveDelegate(OnPreDestroyGameObjectRecursive));
+
+            _detour = new NativeDetour(baseAddress.Add(Offset), hookPtr);
+            original = _detour.GenerateTrampolineWithRecursionSupport<PreDestroyRecursiveDelegate>(14);
+        }
+
+        private static unsafe void OnPreDestroyGameObjectRecursive(IntPtr gameObject, IntPtr something)
+        {
+            var ptr = ((GameObjectStruct*)gameObject.ToPointer())->componentsPtr.ToInt64();
+            if (ptr == 0)
+            {
+                return;
+            }
+
+            original(gameObject, something);
+        }
+    }
+}

--- a/RoR2BepInExPack/Utilities/NativeDetourExtensions.cs
+++ b/RoR2BepInExPack/Utilities/NativeDetourExtensions.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using MonoMod.RuntimeDetour;
+using MonoMod.Utils;
+
+namespace RoR2BepInExPack.Utilities
+{
+    public static class NativeDetourExtensions
+    {
+        private static readonly FieldInfo backupNativeField = typeof(NativeDetour).GetField("_BackupNative", (BindingFlags)(-1));
+
+        /// <summary>
+        /// Generate a new delegate with which you can invoke the previous state.
+        /// Instead of an "undo-call-redo" trampoline generated with <see cref="NativeDetour.GenerateTrampoline{T}()"/>
+        /// copies bytesCount bytes from original method into the trampoline and then puts detour back to the original method,
+        /// effectively splitting the method.
+        /// <para/> This way of doing trampoline has restrictions:
+        /// <para/>    Part of the method that is in trampoline can't have jumps.
+        /// <para/>    The method split should happen between two instructions,
+        ///     so you need to supply the amount of bytes that is >= 14 (max size of a detour) and is on the edge of an instruction.
+        /// </summary>
+        /// <param name="detour">Native detour</param>
+        /// <param name="bytesCount">The amount of bytes to copy from original method</param>
+        public static T GenerateTrampolineWithRecursionSupport<T>(this NativeDetour detour, uint bytesCount) where T : Delegate
+        {
+            if (!typeof(Delegate).IsAssignableFrom(typeof(T)))
+            {
+                throw new InvalidOperationException($"Type {typeof(T)} not a delegate type.");
+            }
+
+            return detour.GenerateNativeProxy(typeof(T).GetMethod("Invoke"), bytesCount).CreateDelegate(typeof(T)) as T;
+        }
+
+        /// <summary>
+        /// Generate a method that executes part of the detoured method then jumps to the original method to continue execution
+        /// </summary>
+        /// <param name="detour">Native detour</param>
+        /// <param name="signature">A MethodBase with the target function's signature.</param>
+        /// <param name="bytesCount">The amount of bytes to copy from original method</param>
+        /// <returns>The detoured DynamicMethod.</returns>
+        public static MethodInfo GenerateNativeProxy(this NativeDetour detour, MethodBase signature, uint bytesCount)
+        {
+            var returnType = (signature as MethodInfo)?.ReturnType ?? typeof(void);
+            var args = signature.GetParameters();
+            var argTypes = new Type[args.Length];
+            for (var i = 0; i < args.Length; i++)
+            {
+                argTypes[i] = args[i].ParameterType;
+            }
+
+            MethodInfo dm;
+            using (var dmd = new DynamicMethodDefinition(
+                $"Native<{((long)detour.Data.Method).ToString("X16", CultureInfo.InvariantCulture)}>",
+                returnType, argTypes))
+            {
+                dm = dmd.StubCriticalDetour().Generate().Pin();
+            }
+
+            var start = dm.GetNativeStart();
+            var detourData = DetourHelper.Native.Create(start.Add(bytesCount), detour.Data.Method.Add(bytesCount));
+            var fakeDetourData = new NativeDetourData
+            {
+                Method = start,
+                Size = bytesCount + detourData.Size,
+            };
+
+            DetourHelper.Native.MakeWritable(fakeDetourData);
+
+            var backupNative = (IntPtr)backupNativeField.GetValue(detour);
+            var extraBytes = bytesCount - detour.Data.Size;
+
+            Write(backupNative, start, detour.Data.Size);
+            if (extraBytes > 0)
+            {
+                Write(detour.Data.Method.Add(detour.Data.Size), start.Add(detour.Data.Size), extraBytes);
+            }
+
+            DetourHelper.Native.Apply(detourData);
+            DetourHelper.Native.MakeExecutable(fakeDetourData);
+            DetourHelper.Native.FlushICache(fakeDetourData);
+            DetourHelper.Native.Free(fakeDetourData);
+
+            return dm;
+        }
+
+        private static unsafe void Write(IntPtr from, IntPtr to, uint size)
+        {
+            var fromPtr = (byte*)from.ToPointer();
+
+            var offs = 0;
+            for (var i = 0; i < size; i++)
+            {
+                to.Write(ref offs, fromPtr[i]);
+            }
+        }
+
+        public static IntPtr Add(this IntPtr ptr, long offset)
+        {
+            return new IntPtr(ptr.ToInt64() + offset);
+        }
+
+        public static IntPtr Add(this IntPtr ptr, uint offset)
+        {
+            return new IntPtr(ptr.ToInt64() + offset);
+        }
+    }
+}

--- a/Thunderstore/manifest.json
+++ b/Thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RoR2BepInExPack",
-  "version_number": "1.14.0",
+  "version_number": "1.15.0",
   "website_url": "https://github.com/risk-of-thunder/RoR2BepInExPack",
   "description": "Simplify the modding ecosystem of Risk of Rain 2, making it easier for modders to create and maintain their mods while preventing harmful bugs.",
   "dependencies": []


### PR DESCRIPTION
tl;dr; Since Unity vesrion update to 2019.4.37 some mods cause the game to crash when existing it, because of the way they create runtime prefabs.
Discord conversation: https://discord.com/channels/562704639141740588/562711077453037589/1257687310087225456

Some mods add prefabs loaded from asset bundles directly as children to runtime prefabs instantiated with PrefabsAPI.InstantiateClone. And it seems like these prefabs are destroyed before runtime prefabs when the game is closing, which results in a harmless, but certainly annoying crash.

Added null check to 2 native functions to avoid the crash. Added custom GenerateTrampoline method, because the one from MonoMod doesn't work with recursive functions.