### PR TITLE
Fix lobby compatibility for DLC2 with additional difficulties

### DIFF
--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -71,6 +71,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixDedicatedServerMaxPlayerCount.Init();
         FixHasEffectiveAuthority.Init();
         FixSystemInitializer.Init();
+        FixRuleBookViewerStrip.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -99,6 +100,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixCharacterBodyRemoveOldestTimedBuff.Enable();
         FixDedicatedServerMaxPlayerCount.Enable();
         FixHasEffectiveAuthority.Enable();
+        FixRuleBookViewerStrip.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -127,6 +129,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixDeathAnimLog.Disable();
         FixConsoleLog.Disable();
         FixConVar.Disable();
+        FixRuleBookViewerStrip.Disable();
         SaferSearchableAttribute.Disable();
         SaferResourceAvailability.Disable();
         SaferAchievementManager.Disable();
@@ -155,6 +158,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixDeathAnimLog.Destroy();
         FixConsoleLog.Destroy();
         FixConVar.Destroy();
+        FixRuleBookViewerStrip.Destroy();
         SaferSearchableAttribute.Destroy();
         SaferResourceAvailability.Destroy();
         SaferAchievementManager.Destroy();

--- a/RoR2BepInExPack/VanillaFixes/FixRuleBookViewerStrip.cs
+++ b/RoR2BepInExPack/VanillaFixes/FixRuleBookViewerStrip.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using MonoMod.RuntimeDetour;
+using RoR2;
+using RoR2.UI;
+using RoR2BepInExPack.Reflection;
+using UnityEngine.UI;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+// Interface added to toggle tutorial mode has invalid range check, and overflows outside 
+// parent. This causes issues as soon as any other difficulty is added. Solution is to 
+// reintroduce missing layout element and find the correct index.
+internal class FixRuleBookViewerStrip
+{
+    private static Hook _hook = null;
+
+    internal static void Init()
+    {
+        _hook ??= new Hook(
+                typeof(RuleBookViewerStrip).GetMethod(
+                        nameof(RuleBookViewerStrip.SetData), ReflectionHelper.AllFlags),
+                typeof(FixRuleBookViewerStrip).GetMethod(
+                        nameof(FindIndexAndSetWidth), ReflectionHelper.AllFlags),
+                new HookConfig() { ManualApply = true }
+            );
+    }
+
+    internal static void Enable()
+    {
+        _hook?.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _hook?.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _hook?.Free();
+        _hook = null;
+    }
+
+    private static void FindIndexAndSetWidth(
+            Action<RuleBookViewerStrip, List<RuleChoiceDef>, int> orig,
+            RuleBookViewerStrip self, List<RuleChoiceDef> choices, int index)
+    {
+        orig(self, choices, index);
+
+        for (int i = 0, count = choices.Count; i < count; ++i)
+        {
+            if (index == choices[i].localIndex)
+            {
+                self.currentDisplayChoiceIndex = i;
+                break;
+            }
+        }
+
+        if (!self.GetComponent<LayoutElement>())
+        {
+            self.gameObject.AddComponent<LayoutElement>().minWidth = 64;
+        }
+    }
+}


### PR DESCRIPTION
With the ***Seekers of the Storm*** update an interface got added to toggle tutorial mode in the lobby. Unfortunately, the changes made to support this cause issues with the difficulty carousel once other options are added, even breaking it entirely if enough are present.

[xiaoxiao921/RoR2_diff_20_05_2024:RuleBookViewerStrip.cs@779e6e7#L53-L57](https://github.com/xiaoxiao921/RoR2_diff_20_05_2024/blame/779e6e788824611153e2037de14325d376ed11e6/DecompilationOutput/RoR2.UI/RuleBookViewerStrip.cs#L53-L57)

Their implementation does not allow to select any rule choice index greater than the number of available options - this is problematic as those are not always consecutive. A layout element was also removed causing these to overflow and become inaccessible.

https://github.com/TeamMoonstorm/Starstorm2/issues/626
https://github.com/6thmoon/MultitudesDifficulty/issues/8#issuecomment-2461715317

See the reports above for a visual example. Note that those and [others](https://thunderstore.io/package/sheen/EclipseMultiplayer) [affected](https://thunderstore.io/package/Groove_Salad/UntitledDifficultyMod) do not always utilize `DifficultyAPI`.