### PR TITLE
Log caught exception in network delegate invocation

### DIFF
--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -72,6 +72,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixHasEffectiveAuthority.Init();
         FixSystemInitializer.Init();
         FixRuleBookViewerStrip.Init();
+        LogNetworkInvokeException.Init();
 
         LegacyResourcesDetours.Init();
         LegacyShaderDetours.Init();
@@ -101,6 +102,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         FixDedicatedServerMaxPlayerCount.Enable();
         FixHasEffectiveAuthority.Enable();
         FixRuleBookViewerStrip.Enable();
+        LogNetworkInvokeException.Enable();
 
         LegacyResourcesDetours.Enable();
         LegacyShaderDetours.Enable();
@@ -115,6 +117,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Disable();
         LegacyResourcesDetours.Disable();
 
+        LogNetworkInvokeException.Disable();
         FixHasEffectiveAuthority.Disable();
         FixDedicatedServerMaxPlayerCount.Disable();
         FixCharacterBodyRemoveOldestTimedBuff.Disable();
@@ -144,6 +147,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Destroy();
         LegacyResourcesDetours.Destroy();
 
+        LogNetworkInvokeException.Destroy();
         FixHasEffectiveAuthority.Destroy();
         FixDedicatedServerMaxPlayerCount.Destroy();
         FixCharacterBodyRemoveOldestTimedBuff.Destroy();

--- a/RoR2BepInExPack/VanillaFixes/LogNetworkInvokeException.cs
+++ b/RoR2BepInExPack/VanillaFixes/LogNetworkInvokeException.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+using UnityEngine.Networking;
+using static Mono.Cecil.Cil.OpCodes;
+
+namespace RoR2BepInExPack.VanillaFixes;
+internal static class LogNetworkInvokeException
+{
+    private static IDetour _detour;
+
+    internal static void Init()
+    {
+        _detour = new ILHook(
+            typeof(NetworkConnection).GetMethod(nameof(NetworkConnection.InvokeDelegateWithCatch)),
+            AddExceptionLogging,
+            new ILHookConfig { ManualApply = true });
+    }
+
+    internal static void Enable()
+    {
+        _detour.Apply();
+    }
+
+    internal static void Disable()
+    {
+        _detour.Undo();
+    }
+
+    internal static void Destroy()
+    {
+        _detour.Free();
+    }
+
+    private static void AddExceptionLogging(ILContext il)
+    {
+        var c = new ILCursor(il);
+        // goto catch (Exception)
+        if (c.TryGotoNext(
+            a => a.MatchLeaveS(out _),
+            a => a.MatchPop(),
+            a => a.MatchLdstr(out _)))
+        {
+            // store exception instead of popping it
+            c.Index += 1;
+            var exception = new VariableDefinition(c.Body.Method.Module.ImportReference(typeof(Exception)));
+            c.Body.Variables.Add(exception);
+            c.Next.Operand = exception;
+            c.Next.OpCode = Stloc;
+
+            // append exception to text
+            c.Index += 2;
+            c.Prev.Operand += Environment.NewLine + "{0}";
+            c.Emit(Ldloc, exception);
+            c.Emit(Call, ((Func<string, object, string>)string.Format).Method);
+        }
+        else
+            Log.Error($"ILHook {nameof(LogNetworkInvokeException)}.{nameof(AddExceptionLogging)} failed.");
+    }
+}


### PR DESCRIPTION
NetworkConnection.InvokeDelegateWithCatch is a method added by hopoo that try-catches invocation of network handlers such as [TargetRpc] and [Command]. However it doesnt log the exception, making it not useful for logs and hides potential issues.

Appends exception to the error message of "Failed at InvokeHandler, probably malformed packet!"