### PR TITLE
Fix for Nullref on MatchBr in HarmonyILManipulator hooks

### DIFF
--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -82,6 +82,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Init();
 
         FixMultiCorrupt.Init(Config);
+        HarmonyMatchException.Init();
     }
 
     private static void EnableHooks()
@@ -112,6 +113,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         LegacyShaderDetours.Enable();
 
         FixMultiCorrupt.Enable();
+        HarmonyMatchException.Enable();
     }
 
     private static void DisableHooks()
@@ -142,6 +144,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferAchievementManager.Disable();
         AutoCatchReflectionTypeLoadException.Disable();
         ILLine.Disable();
+        HarmonyMatchException.Disable();
     }
 
     private static void DestroyHooks()
@@ -172,6 +175,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferAchievementManager.Destroy();
         AutoCatchReflectionTypeLoadException.Destroy();
         ILLine.Destroy();
+        HarmonyMatchException.Destroy();
     }
 
     private void OnApplicationQuitting()

--- a/RoR2BepInExPack/RoR2BepInExPack.cs
+++ b/RoR2BepInExPack/RoR2BepInExPack.cs
@@ -118,6 +118,7 @@ public class RoR2BepInExPack : BaseUnityPlugin
 
     private static void DisableHooks()
     {
+        HarmonyMatchException.Disable();
         FixMultiCorrupt.Disable();
 
         LegacyShaderDetours.Disable();
@@ -144,11 +145,11 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferAchievementManager.Disable();
         AutoCatchReflectionTypeLoadException.Disable();
         ILLine.Disable();
-        HarmonyMatchException.Disable();
     }
 
     private static void DestroyHooks()
     {
+        HarmonyMatchException.Destroy();
         FixMultiCorrupt.Destroy();
 
         LegacyShaderDetours.Destroy();
@@ -175,7 +176,6 @@ public class RoR2BepInExPack : BaseUnityPlugin
         SaferAchievementManager.Destroy();
         AutoCatchReflectionTypeLoadException.Destroy();
         ILLine.Destroy();
-        HarmonyMatchException.Destroy();
     }
 
     private void OnApplicationQuitting()

--- a/RoR2BepInExPack/RoR2BepInExPack.csproj
+++ b/RoR2BepInExPack/RoR2BepInExPack.csproj
@@ -17,7 +17,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
-		<PackageReference Include="BepInEx.Core" Version="5.4.19" />
+		<PackageReference Include="BepInEx.Core" Version="5.4.21" />
 		<PackageReference Include="RiskOfRain2.GameLibs" Version="*-*" />
 	</ItemGroup>
 

--- a/RoR2BepInExPack/UnityEngineHooks/HarmonyMatchException.cs
+++ b/RoR2BepInExPack/UnityEngineHooks/HarmonyMatchException.cs
@@ -10,8 +10,10 @@ using MonoMod.RuntimeDetour;
 
 namespace RoR2BepInExPack.VanillaFixes;
 
-[HarmonyPatch]
-public class MatchFailTest
+// commenting this out cuz debug builds are fucked lol
+
+/*[HarmonyPatch]
+internal class MatchFailTest
 {
     [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
     [HarmonyPrefix]
@@ -37,51 +39,75 @@ public class MatchFailTest
         c.TryFindNext(out c2, x => x.MatchBrfalse(out _));
         c.TryFindNext(out c2, x => x.MatchBr(out _));
     }
-}
+}*/
 
-public class HarmonyMatchException
+internal class HarmonyMatchException
 {
     private static ILHook _hook;
-    private static Harmony _harmony;
+
+    //private static Harmony _harmony;
 
     internal static void Init()
     {
-        _harmony = new Harmony(nameof(HarmonyMatchException));
+        //_harmony = new Harmony(nameof(HarmonyMatchException));
 
         var method = AccessTools.DeclaredMethod(typeof(HarmonyManipulator), "ApplyManipulators") ?? AccessTools.DeclaredMethod(typeof(HarmonyManipulator), "ApplyILManipulators");
         if (method is null)
+        {
+            Log.Error($"Could not apply fix for {nameof(HarmonyMatchException)}, target method is invalid");
             return;
+        }
 
-        //_hook = new ILHook(method, FixHarmonyMatchException, new ILHookConfig { ManualApply = true });
+        _hook = new ILHook(method, FixHarmonyMatchException, new ILHookConfig { ManualApply = true });
     }
+    /*
+    internal static IEnumerator TestDmdHook()
+    {
+        yield return null;
+
+        if (true)
+        {
+            yield return null;
+        }
+        if (false)
+        {
+            yield return null;
+        }
+        yield break;
+    }
+    */
     internal static void Enable()
     {
         _hook?.Apply();
-        _harmony.CreateClassProcessor(typeof(MatchFailTest)).Patch();
+        //_harmony.CreateClassProcessor(typeof(MatchFailTest)).Patch();
     }
 
     internal static void Disable()
     {
         _hook?.Undo();
-        _harmony?.UnpatchSelf();
+        //_harmony?.UnpatchSelf();
     }
 
     internal static void Destroy()
     {
         _hook?.Free();
-        _harmony = null;
+        //_harmony = null;
     }
 
     // Replaces the call to GetFileLineNumber to a call to GetLineOrIL
-    public static void FixHarmonyMatchException(ILContext il)
+    internal static void FixHarmonyMatchException(ILContext il)
     {
         var c = new ILCursor(il);
-        c.GotoNext(MoveType.AfterLabel,
+        if (!c.TryGotoNext(MoveType.AfterLabel,
                 x => x.MatchLdnull(),
                 x => x.MatchLdloc(out _),
                 x => x.MatchCallvirt(out _),
                 x => x.MatchCallvirt(AccessTools.Method(typeof(MethodBase), nameof(MethodBase.Invoke), [typeof(object), typeof(object[])])),
-                x => x.MatchPop());
+                x => x.MatchPop()))
+        {
+            Log.Error($"Could not apply fix for {nameof(FixHarmonyMatchException)}");
+            return;
+        }
 
         c.Emit(OpCodes.Ldarg_0);
         c.EmitDelegate(ApplyILLabels);
@@ -91,7 +117,7 @@ public class HarmonyMatchException
         c.EmitDelegate(UnApplyILLabels);
     }
 
-    public static void ApplyILLabels(ILContext il)
+    internal static void ApplyILLabels(ILContext il)
     {
         if (il?.Instrs is null)
             return;
@@ -108,7 +134,7 @@ public class HarmonyMatchException
         }
     }
 
-    public static void UnApplyILLabels(ILContext il)
+    internal static void UnApplyILLabels(ILContext il)
     {
         if (il?.Instrs is null || il.IsReadOnly)
             return;
@@ -123,20 +149,5 @@ public class HarmonyMatchException
             else if (instr.Operand is ILLabel[] targets)
                 instr.Operand = targets.Select(l => l.Target).ToArray();
         }
-    }
-
-    public static IEnumerator TestDmdHook()
-    {
-        yield return null;
-
-        if (true)
-        {
-            yield return null;
-        }
-        if (false)
-        {
-            yield return null;
-        }
-        yield break;
     }
 }

--- a/RoR2BepInExPack/UnityEngineHooks/HarmonyMatchException.cs
+++ b/RoR2BepInExPack/UnityEngineHooks/HarmonyMatchException.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using HarmonyLib;
-using HarmonyLib.Internal.Util;
 using HarmonyLib.Public.Patching;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
@@ -13,59 +10,119 @@ using MonoMod.RuntimeDetour;
 
 namespace RoR2BepInExPack.VanillaFixes;
 
-// Original code from mistername
-
 [HarmonyPatch]
-internal class HarmonyMatchException
+public class MatchFailTest
 {
-    private static Harmony _harmony;
-    private static ILHook _hook;
+    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
+    [HarmonyPrefix]
+    public static void Prefix()
+    {
+    }
 
-#if DEBUG
-    private static Hook _testHook;
-#endif
+    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> TransRights(IEnumerable<CodeInstruction> instructions)
+    {
+        foreach (var i in instructions)
+            yield return i;
+    }
+
+    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    public static void ILHook(ILContext il)
+    {
+        var c = new ILCursor(il);
+        ILCursor[] c2 = null;
+        c.TryFindNext(out c2, x => x.MatchBrtrue(out _));
+        c.TryFindNext(out c2, x => x.MatchBrfalse(out _));
+        c.TryFindNext(out c2, x => x.MatchBr(out _));
+    }
+}
+
+public class HarmonyMatchException
+{
+    private static ILHook _hook;
+    private static Harmony _harmony;
 
     internal static void Init()
     {
-        foreach (var method in typeof(HarmonyManipulator).GetMethods())
-        {
-            Log.Warning(method.Name);
-        }
-        _hook = new ILHook(AccessTools.DeclaredMethod(typeof(HarmonyManipulator), "ApplyILManipulators"), FixHarmonyMatchException, new ILHookConfig() { ManualApply = true });
+        _harmony = new Harmony(nameof(HarmonyMatchException));
 
-#if DEBUG
-        _testHook = new Hook(AccessTools.EnumeratorMoveNext(typeof(HarmonyMatchException).GetMethod(nameof(HarmonyMatchException.TestDmdHook), ~BindingFlags.Default)), Hookthing);
+        var method = AccessTools.DeclaredMethod(typeof(HarmonyManipulator), "ApplyManipulators") ?? AccessTools.DeclaredMethod(typeof(HarmonyManipulator), "ApplyILManipulators");
+        if (method is null)
+            return;
 
-        try
-        {
-            _harmony = new Harmony(nameof(HarmonyMatchException));
-        }
-        catch (Exception ex)
-        {
-            Log.Error($"Testing IL Lines from DMDs{Environment.NewLine}{ex}");
-        }
-#endif
+        //_hook = new ILHook(method, FixHarmonyMatchException, new ILHookConfig { ManualApply = true });
+    }
+    internal static void Enable()
+    {
+        _hook?.Apply();
+        _harmony.CreateClassProcessor(typeof(MatchFailTest)).Patch();
     }
 
-#if DEBUG
-    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
-    [HarmonyPrefix]
-    public static void ItemDisplayRuleSet_GenerateRuntimeValuesAsync7(ILContext il)
+    internal static void Disable()
+    {
+        _hook?.Undo();
+        _harmony?.UnpatchSelf();
+    }
+
+    internal static void Destroy()
+    {
+        _hook?.Free();
+        _harmony = null;
+    }
+
+    // Replaces the call to GetFileLineNumber to a call to GetLineOrIL
+    public static void FixHarmonyMatchException(ILContext il)
     {
         var c = new ILCursor(il);
-        c.TryFindNext(out _, x => x.MatchBrfalse(out _), x => x.MatchBr(out _));
+        c.GotoNext(MoveType.AfterLabel,
+                x => x.MatchLdnull(),
+                x => x.MatchLdloc(out _),
+                x => x.MatchCallvirt(out _),
+                x => x.MatchCallvirt(AccessTools.Method(typeof(MethodBase), nameof(MethodBase.Invoke), [typeof(object), typeof(object[])])),
+                x => x.MatchPop());
+
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate(ApplyILLabels);
+
+        c.GotoNext(MoveType.After, x => x.MatchPop());
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate(UnApplyILLabels);
     }
-    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
-    [HarmonyILManipulator]
-    public static void ItemDisplayRuleSet_GenerateRuntimeValuesAsyncs(ILContext il)
+
+    public static void ApplyILLabels(ILContext il)
     {
-        var c = new ILCursor(il);
-        c.TryFindNext(out _, x => x.MatchBrfalse(out _), x => x.MatchBr(out _));
+        if (il?.Instrs is null)
+            return;
+
+        foreach (var instr in il.Instrs)
+        {
+            if (instr?.Operand is null)
+                continue;
+
+            if (instr.Operand is Instruction target)
+                instr.Operand = il.DefineLabel(target);
+            else if (instr.Operand is Instruction[] targets)
+                instr.Operand = targets.Select(t => il.DefineLabel(t)).ToArray();
+        }
     }
-    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
-    [HarmonyPrefix]
-    public static void ItemDisplayRuleSet_GenerateRuntimeValuesAsyncss()
+
+    public static void UnApplyILLabels(ILContext il)
     {
+        if (il?.Instrs is null || il.IsReadOnly)
+            return;
+
+        foreach (var instr in il.Instrs)
+        {
+            if (instr?.Operand is null)
+                continue;
+
+            if (instr.Operand is ILLabel label)
+                instr.Operand = label.Target;
+            else if (instr.Operand is ILLabel[] targets)
+                instr.Operand = targets.Select(l => l.Target).ToArray();
+        }
     }
 
     public static IEnumerator TestDmdHook()
@@ -81,70 +138,5 @@ internal class HarmonyMatchException
             yield return null;
         }
         yield break;
-    }
-    public static bool Hookthing(Func<IEnumerator, bool> orig, IEnumerator self)
-    {
-        return orig(self);
-    }
-#endif
-
-    internal static void Enable()
-    {
-        _hook.Apply();
-        _harmony.CreateClassProcessor(typeof(HarmonyMatchException)).Patch();
-    }
-
-    internal static void Disable()
-    {
-        _hook.Undo();
-        _harmony.UnpatchSelf();
-    }
-
-    internal static void Destroy()
-    {
-        _hook.Free();
-    }
-
-    // Replaces the call to GetFileLineNumber to a call to GetLineOrIL
-    public static void FixHarmonyMatchException(ILContext il)
-    {
-        var c = new ILCursor(il) { Index = il.Instrs.Count - 1};
-        c.GotoPrev(MoveType.AfterLabel, x => x.MatchRet());
-        c.Emit(OpCodes.Ldarg_0);
-        c.EmitDelegate(UnApplyILLabels);
-        /*
-			IL_00ea: callvirt instance object [mscorlib]System.Reflection.MethodBase::Invoke(object, object[])
-			IL_00ef: pop
-*/
-        c = new ILCursor(il);
-        c.GotoNext(MoveType.After,
-               x => x.MatchCallvirt(AccessTools.Method(typeof(MethodBase), nameof(MethodBase.Invoke), [typeof(object), typeof(object[])])),
-               x => x.MatchPop()
-            );
-        c.Emit(OpCodes.Ldarg_0);
-        c.EmitDelegate(ApplyILLabels);
-    }
-
-    public static void ApplyILLabels(ILContext il)
-    {
-        foreach (var instr in il.Instrs)
-        {
-            if (instr.Operand is Instruction target)
-                instr.Operand = il.DefineLabel(target);
-            else if (instr.Operand is Instruction[] targets)
-                instr.Operand = targets.Select(il.DefineLabel).ToArray();
-        }
-
-    }
-    public static void UnApplyILLabels(ILContext il)
-    {
-        foreach (var instr in il.Instrs)
-        {
-            if (instr.Operand is ILLabel label)
-                instr.Operand = label.Target;
-            else if (instr.Operand is ILLabel[] targets)
-                instr.Operand = targets.Select(l => l.Target).ToArray();
-        }
-
     }
 }

--- a/RoR2BepInExPack/UnityEngineHooks/HarmonyMatchException.cs
+++ b/RoR2BepInExPack/UnityEngineHooks/HarmonyMatchException.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using HarmonyLib.Internal.Util;
+using HarmonyLib.Public.Patching;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+
+namespace RoR2BepInExPack.VanillaFixes;
+
+// Original code from mistername
+
+[HarmonyPatch]
+internal class HarmonyMatchException
+{
+    private static Harmony _harmony;
+    private static ILHook _hook;
+
+#if DEBUG
+    private static Hook _testHook;
+#endif
+
+    internal static void Init()
+    {
+        foreach (var method in typeof(HarmonyManipulator).GetMethods())
+        {
+            Log.Warning(method.Name);
+        }
+        _hook = new ILHook(AccessTools.DeclaredMethod(typeof(HarmonyManipulator), "ApplyILManipulators"), FixHarmonyMatchException, new ILHookConfig() { ManualApply = true });
+
+#if DEBUG
+        _testHook = new Hook(AccessTools.EnumeratorMoveNext(typeof(HarmonyMatchException).GetMethod(nameof(HarmonyMatchException.TestDmdHook), ~BindingFlags.Default)), Hookthing);
+
+        try
+        {
+            _harmony = new Harmony(nameof(HarmonyMatchException));
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Testing IL Lines from DMDs{Environment.NewLine}{ex}");
+        }
+#endif
+    }
+
+#if DEBUG
+    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
+    [HarmonyPrefix]
+    public static void ItemDisplayRuleSet_GenerateRuntimeValuesAsync7(ILContext il)
+    {
+        var c = new ILCursor(il);
+        c.TryFindNext(out _, x => x.MatchBrfalse(out _), x => x.MatchBr(out _));
+    }
+    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    public static void ItemDisplayRuleSet_GenerateRuntimeValuesAsyncs(ILContext il)
+    {
+        var c = new ILCursor(il);
+        c.TryFindNext(out _, x => x.MatchBrfalse(out _), x => x.MatchBr(out _));
+    }
+    [HarmonyPatch(typeof(HarmonyMatchException), nameof(HarmonyMatchException.TestDmdHook), MethodType.Enumerator)]
+    [HarmonyPrefix]
+    public static void ItemDisplayRuleSet_GenerateRuntimeValuesAsyncss()
+    {
+    }
+
+    public static IEnumerator TestDmdHook()
+    {
+        yield return null;
+
+        if (true)
+        {
+            yield return null;
+        }
+        if (false)
+        {
+            yield return null;
+        }
+        yield break;
+    }
+    public static bool Hookthing(Func<IEnumerator, bool> orig, IEnumerator self)
+    {
+        return orig(self);
+    }
+#endif
+
+    internal static void Enable()
+    {
+        _hook.Apply();
+        _harmony.CreateClassProcessor(typeof(HarmonyMatchException)).Patch();
+    }
+
+    internal static void Disable()
+    {
+        _hook.Undo();
+        _harmony.UnpatchSelf();
+    }
+
+    internal static void Destroy()
+    {
+        _hook.Free();
+    }
+
+    // Replaces the call to GetFileLineNumber to a call to GetLineOrIL
+    public static void FixHarmonyMatchException(ILContext il)
+    {
+        var c = new ILCursor(il) { Index = il.Instrs.Count - 1};
+        c.GotoPrev(MoveType.AfterLabel, x => x.MatchRet());
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate(UnApplyILLabels);
+        /*
+			IL_00ea: callvirt instance object [mscorlib]System.Reflection.MethodBase::Invoke(object, object[])
+			IL_00ef: pop
+*/
+        c = new ILCursor(il);
+        c.GotoNext(MoveType.After,
+               x => x.MatchCallvirt(AccessTools.Method(typeof(MethodBase), nameof(MethodBase.Invoke), [typeof(object), typeof(object[])])),
+               x => x.MatchPop()
+            );
+        c.Emit(OpCodes.Ldarg_0);
+        c.EmitDelegate(ApplyILLabels);
+    }
+
+    public static void ApplyILLabels(ILContext il)
+    {
+        foreach (var instr in il.Instrs)
+        {
+            if (instr.Operand is Instruction target)
+                instr.Operand = il.DefineLabel(target);
+            else if (instr.Operand is Instruction[] targets)
+                instr.Operand = targets.Select(il.DefineLabel).ToArray();
+        }
+
+    }
+    public static void UnApplyILLabels(ILContext il)
+    {
+        foreach (var instr in il.Instrs)
+        {
+            if (instr.Operand is ILLabel label)
+                instr.Operand = label.Target;
+            else if (instr.Operand is ILLabel[] targets)
+                instr.Operand = targets.Select(l => l.Target).ToArray();
+        }
+
+    }
+}


### PR DESCRIPTION
![{45B8241B-B0FE-4C42-B6F6-630CB60EC67F}](https://github.com/user-attachments/assets/d6ac9e70-b074-4b8b-8488-3f63f36f4ed2)

Fix mimics the behavior of MonoMod

https://github.com/MonoMod/MonoMod/blob/d96406c2/src/MonoMod.Utils/Cil/ILContext.cs#L73-L105