### PR TITLE
Add MonoDetour hook support for HookWatcher

### DIFF
--- a/src/HookWatcher.cs
+++ b/src/HookWatcher.cs
@@ -19,11 +19,18 @@ internal static class HookWatcher
 
     private static Hook _harmonyWatcher = null!;
 
-    private static bool isMonoDetourPresent;
+    private static bool _isMonoDetourPresent = false;
 
     internal static void Init()
     {
-        isMonoDetourPresent = Type.GetType("MonoDetour.MonoDetourHook, com.github.MonoDetour") is not null;
+        try
+        {
+            _isMonoDetourPresent = Type.GetType("MonoDetour.MonoDetourHook, com.github.MonoDetour")?.GetMethod("TryGetFrom") is not null;
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+        }
 
         ModManager = new DetourModManager();
 
@@ -80,14 +87,14 @@ internal static class HookWatcher
     }
 
     private static void LogOnHook(Assembly hookOwner, MethodBase from, MethodBase to, object target)
-        => LogHookAndMaybeRedirect(new() { Kind = HookInfo.HookKind.On, Owner = hookOwner, OriginalManaged = from, HookMethodBase = to });
+        => LogHook(new() { Kind = HookInfo.HookKind.On, Owner = hookOwner, OriginalManaged = from, HookMethodBase = to });
 
     private static void LogILHook(Assembly hookOwner, MethodBase from, ILContext.Manipulator manipulator)
     {
-        if (isMonoDetourPresent && IfMonoDetourHookDoSpecializedLog(manipulator, from))
+        if (_isMonoDetourPresent && IfMonoDetourHookDoSpecializedLog(manipulator, from))
             return;
 
-        LogHookAndMaybeRedirect(new() { Kind = HookInfo.HookKind.IL, Owner = hookOwner, OriginalManaged = from, HookDelegate = manipulator });
+        LogHook(new() { Kind = HookInfo.HookKind.IL, Owner = hookOwner, OriginalManaged = from, HookDelegate = manipulator });
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -102,7 +109,7 @@ internal static class HookWatcher
         else
             applierTypeName = hook.ApplierType.Name;
 
-        LogHookAndMaybeRedirect(
+        LogHook(
             new() { Kind = HookInfo.HookKind.IL, Owner = hook.Manipulator.Module.Assembly, OriginalManaged = from, HookMethodBase = hook.Manipulator },
             specifier: $" MonoDetour<{applierTypeName}>"
         );
@@ -111,16 +118,16 @@ internal static class HookWatcher
     }
 
     private static void LogDetour(Assembly hookOwner, MethodBase from, MethodBase to)
-        => LogHookAndMaybeRedirect(new() { Kind = HookInfo.HookKind.On, Owner = hookOwner, OriginalManaged = from, HookMethodBase = to });
+        => LogHook(new() { Kind = HookInfo.HookKind.On, Owner = hookOwner, OriginalManaged = from, HookMethodBase = to });
 
     private static void LogNativeDetour(Assembly hookOwner, MethodBase originalMethod, IntPtr from, IntPtr to)
-        => LogHookAndMaybeRedirect(new() { Kind = HookInfo.HookKind.Native, Owner = hookOwner, OriginalNative = from, HookIntPtr = to });
+        => LogHook(new() { Kind = HookInfo.HookKind.Native, Owner = hookOwner, OriginalNative = from, HookIntPtr = to });
 
     private static bool LogHookAdd(MethodBase from, Delegate to)
     {
         var info = GetHookInfo(from, to);
 
-        return LogHookAndMaybeRedirect(info);
+        return LogHook(info);
     }
 
     private static bool LogHookModify(MethodBase from, Delegate to)
@@ -128,14 +135,14 @@ internal static class HookWatcher
         var info = GetHookInfo(from, to);
 
         // Seems to be only used by IL Manipulators?
-        return LogHookAndMaybeRedirect(info, "modifier");
+        return LogHook(info, "modifier");
     }
 
     private static bool LogHookRemove(MethodBase from, Delegate to)
     {
         var info = GetHookInfo(from, to);
 
-        return LogHookAndMaybeRedirect(info, "removed");
+        return LogHook(info, "removed");
     }
 
     private static HookInfo GetHookInfo(MethodBase from, Delegate to)
@@ -182,7 +189,7 @@ internal static class HookWatcher
     }
 
     internal static bool RedirectFixFrameRateDependantLogicHooks = false;
-    private static bool LogHookAndMaybeRedirect(HookInfo hookInfo, string context = "added", string? specifier = null)
+    private static bool LogHook(HookInfo hookInfo, string context = "added", string? specifier = null)
     {
         if (hookInfo.OriginalManaged == null)
         {

--- a/src/HookWatcher.cs
+++ b/src/HookWatcher.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using HarmonyLib;
+using MonoDetour;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using MonoMod.RuntimeDetour.HookGen;
@@ -9,14 +11,20 @@ using RoR2BepInExPack.Reflection;
 
 namespace RoR2BepInExPack;
 
+#nullable enable
+
 internal static class HookWatcher
 {
-    private static DetourModManager ModManager { get; set; }
+    private static DetourModManager ModManager { get; set; } = null!;
 
-    private static Hook _harmonyWatcher;
+    private static Hook _harmonyWatcher = null!;
+
+    private static bool isMonoDetourPresent;
 
     internal static void Init()
     {
+        isMonoDetourPresent = Type.GetType("MonoDetour.MonoDetourHook, com.github.MonoDetour") is not null;
+
         ModManager = new DetourModManager();
 
         ModManager.OnHook += LogOnHook;
@@ -68,14 +76,39 @@ internal static class HookWatcher
         ModManager.OnHook -= LogOnHook;
 
         ModManager.Dispose();
-        ModManager = null;
+        ModManager = null!;
     }
 
     private static void LogOnHook(Assembly hookOwner, MethodBase from, MethodBase to, object target)
         => LogHookAndMaybeRedirect(new() { Kind = HookInfo.HookKind.On, Owner = hookOwner, OriginalManaged = from, HookMethodBase = to });
 
     private static void LogILHook(Assembly hookOwner, MethodBase from, ILContext.Manipulator manipulator)
-        => LogHookAndMaybeRedirect(new() { Kind = HookInfo.HookKind.IL, Owner = hookOwner, OriginalManaged = from, HookDelegate = manipulator });
+    {
+        if (isMonoDetourPresent && IfMonoDetourHookDoSpecializedLog(manipulator, from))
+            return;
+
+        LogHookAndMaybeRedirect(new() { Kind = HookInfo.HookKind.IL, Owner = hookOwner, OriginalManaged = from, HookDelegate = manipulator });
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool IfMonoDetourHookDoSpecializedLog(ILContext.Manipulator manipulator, MethodBase from)
+    {
+        if (!MonoDetourHook.TryGetFrom(manipulator, out var hook))
+            return false;
+
+        string applierTypeName;
+        if (hook.ApplierType.Name.EndsWith("Detour", StringComparison.InvariantCulture))
+            applierTypeName = hook.ApplierType.Name[..^6];
+        else
+            applierTypeName = hook.ApplierType.Name;
+
+        LogHookAndMaybeRedirect(
+            new() { Kind = HookInfo.HookKind.IL, Owner = hook.Manipulator.Module.Assembly, OriginalManaged = from, HookMethodBase = hook.Manipulator },
+            specifier: $" MonoDetour<{applierTypeName}>"
+        );
+
+        return true;
+    }
 
     private static void LogDetour(Assembly hookOwner, MethodBase from, MethodBase to)
         => LogHookAndMaybeRedirect(new() { Kind = HookInfo.HookKind.On, Owner = hookOwner, OriginalManaged = from, HookMethodBase = to });
@@ -138,18 +171,18 @@ internal static class HookWatcher
 
         internal HookKind Kind;
 
-        internal Assembly Owner;
+        internal Assembly? Owner;
 
-        internal MethodBase OriginalManaged;
+        internal MethodBase? OriginalManaged;
         internal IntPtr OriginalNative;
 
-        internal Delegate HookDelegate;
+        internal Delegate? HookDelegate;
         internal IntPtr HookIntPtr;
-        internal MethodBase HookMethodBase;
+        internal MethodBase? HookMethodBase;
     }
 
     internal static bool RedirectFixFrameRateDependantLogicHooks = false;
-    private static bool LogHookAndMaybeRedirect(HookInfo hookInfo, string context = "added")
+    private static bool LogHookAndMaybeRedirect(HookInfo hookInfo, string context = "added", string? specifier = null)
     {
         if (hookInfo.OriginalManaged == null)
         {
@@ -167,7 +200,7 @@ internal static class HookWatcher
         var fromName = hookInfo.OriginalManaged.Name;
         var fromIdentifier = fromDeclaringType != null ? $"{fromDeclaringType.FullName}.{fromName}" : fromName;
 
-        string GetToIdentifier()
+        string? GetToIdentifier()
         {
             if (hookInfo.HookDelegate != null)
             {
@@ -186,7 +219,7 @@ internal static class HookWatcher
             return "";
         }
 
-        Log.Debug($"{hookInfo.Kind}Hook {GetToIdentifier()} {context} by assembly: {hookOwnerDllName} for: {fromIdentifier}");
+        Log.Debug($"{hookInfo.Kind}Hook{specifier} {GetToIdentifier()} {context} by assembly: {hookOwnerDllName} for: {fromIdentifier}");
 
         return true;
     }

--- a/src/RoR2BepInExPack.csproj
+++ b/src/RoR2BepInExPack.csproj
@@ -20,6 +20,7 @@
 		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
 		<PackageReference Include="BepInEx.Core" Version="5.4.21" />
 		<PackageReference Include="RiskOfRain2.GameLibs" Version="*-*" />
+		<PackageReference Include="MonoDetour" Version="0.7.7" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
As of right now, all hooks made with MonoDetour will look something like this:
```cs
ILHook MonoDetour.DetourTypes.PrefixDetour.ApplierManipulator added by assembly: com.github.MonoDetour.dll for: ItemDatabase.OnLoaded
```
With this PR, it would look like this:
```cs
ILHook MonoDetour<Prefix> PEAKLib.Items.Hooks.ItemDatabaseHooks.Prefix_OnLoaded added by assembly: com.github.PEAKModding.PEAKLib.Items.dll for: ItemDatabase.OnLoaded
```
Feel free to change the format. I decided to go with the current one because:
1. It shows it's from MonoDetour
2. It shows what type of MonoDetour's ILHook wrapper it is (`Prefix`, `Postfix`, `ILHook`)
3. This whole thing is pretty short

Regarding 2, the `Detour`-postfix in type names is irrelevant in this context (real names are `PrefixDetour`, `PostfixDetour`, `ILHookDetour`), so it's removed from the string. It not being present also makes it easier to read the detour type.

Note: I didn't test that this works for real in RoR2 because I don't have the game (I did test in PEAK though, but that was a copy paste mostly and this should probably be the same). I would recommend trying it out without MonoDetour installed to see if it didn't break anything. Also if a mod which uses MonoDetour is useful as an example, this is one: <https://thunderstore.io/package/LordVGames/DamageSourceForEquipment/>

oh also I enabled nullable for the file, I'm assuming it's not a problem so I did it.

Oh also also, if there are any issues with the PR, feel free to do any changes without my input.

## Important

MonoDetour 0.7.7 or higher is required for the `MonoDetourHook.TryGetFrom(manipulator, out var hook)` API method (it was released not too long ago since making this PR).